### PR TITLE
Add hyperlink for quansight logo and name

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 # QHub Documentation
 
-![quansight_logo](https://avatars0.githubusercontent.com/u/34879953?v=4&s=100)
+[![quansight_logo](https://avatars0.githubusercontent.com/u/34879953?v=4&s=100)](https://www.quansight.com/)
 
 > Open source tooling for data science research, development, and deployment.
 
-QHub is an integrated data science environment designed and developed by scientists at Quansight. QHub enables teams to build and maintain a cost effective and scalable compute/data science platform in the cloud. It provides an [**Infrastructure as Code**](https://en.wikipedia.org/wiki/Infrastructure_as_code) platform that streamlines the deployment of data science infrastructure for teams.
+QHub is an integrated data science environment designed and developed by scientists at [**Quansight**](https://www.quansight.com/). QHub enables teams to build and maintain a cost effective and scalable compute/data science platform in the cloud. It provides an [**Infrastructure as Code**](https://en.wikipedia.org/wiki/Infrastructure_as_code) platform that streamlines the deployment of data science infrastructure for teams.
 
 ## QHub is for Teams
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # QHub Documentation
 
-[![quansight_logo](https://avatars0.githubusercontent.com/u/34879953?v=4&s=100)](https://www.quansight.com/) 
+[![quansight_logo](https://avatars0.githubusercontent.com/u/34879953?v=4&s=100)](https://www.quansight.com/)
 
 > Open source tooling for data science research, development, and deployment.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # QHub Documentation
 
-[![quansight_logo](https://avatars0.githubusercontent.com/u/34879953?v=4&s=100)](https://www.quansight.com/)
+[![quansight_logo](https://avatars0.githubusercontent.com/u/34879953?v=4&s=100)](https://www.quansight.com/) 
 
 > Open source tooling for data science research, development, and deployment.
 

--- a/qhub/template/hooks/prompt_gen_project.py
+++ b/qhub/template/hooks/prompt_gen_project.py
@@ -136,7 +136,8 @@ def prompt_gcp_config(config):
     config["google_cloud_platform"]["node_groups"] = {}
     for node_group in DEFAULT_CONFIGURATION["node_groups"]:
         instance_type = prompt_dict(
-            f"{node_group} node group instance type", google_cloud.instances(project),
+            f"{node_group} node group instance type",
+            google_cloud.instances(project),
         )
         min_nodes = prompt_range(f"{node_group} node group min nodes", 0, 999_999, 1)
         max_nodes = prompt_range(


### PR DESCRIPTION
Adds hyperlinks to the Quansight logo and the word `Quansight` in the opening paragraph for the documentation. Hyperlink routes to the main Quansight web page.