### PR TITLE
Adding preemptible option to nodegroups for gcp

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/gcp.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/gcp.tf
@@ -33,6 +33,9 @@ module "kubernetes" {
       instance_type = "{{ nodegroup_config.instance }}"
       min_size      = {{ nodegroup_config.min_nodes }}
       max_size      = {{ nodegroup_config.max_nodes }}
+{% if "preemptible" in nodegroup_config %}
+      preemptible   = {{ "true" if nodegroup_config.preemptible else "false" }}
+{% endif %}
     },
 {% endfor %}
   ]


### PR DESCRIPTION
Since we recently added support for preemptible on terraform modules wanted to add the preemptible option to qhub