### PR TITLE
Enable DigitalOcean to use private container registry

### DIFF
--- a/docs/docs/do/installation.md
+++ b/docs/docs/do/installation.md
@@ -33,14 +33,6 @@ variable is due to limitations in Terraform. `AWS_ACCESS_KEY_ID` is
 the same as your `SPACES_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` is
 the same as your `SPACES_SECRET_ACCESS_KEY`.
 
-Since the DigitalOcean [container
-registry](https://www.digitalocean.com/products/container-registry/)
-is not general availability yet and the Terraform [PR for support is
-not merged](https://github.com/terraform-providers/terraform-provider-digitalocean/pull/383) we require an external container registry. The simplest one to choose is Docker hub. Thus for DigitalOcean we also require Docker Hub access tokens ([tutorial](https://docs.docker.com/docker-hub/access-tokens/)).
-
-- `DOCKER_USERNAME`
-- `DOCKER_PASSWORD`
-
 ## Bootstrapping
 
 Terraform is used for all deployments of infrastructure as well as

--- a/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/image.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/image.yaml
@@ -67,18 +67,17 @@ jobs:
         run: |
           docker logout
 {% elif cookiecutter.provider == "do" %}
-      - name: Docker Login
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: {{ '${{ secrets.DIGITALOCEAN_TOKEN }}' }}
+      - name: Digital Ocean Docker Registry Login
         run: |
-          docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-        env:
-          DOCKER_USERNAME: {{ '${{ secrets.docker_username }}' }}
-          DOCKER_PASSWORD: {{ '${{ secrets.docker_password }}' }}
+          doctl registry login
       - name: Docker Build, Tag, and Push Image
         env:
           IMAGE_TAG: {{ '${{ github.sha }}' }}
-          # due to digitalocean not having a public container registry (beta)
-          # https://www.digitalocean.com/products/container-registry/
-          IMAGE_NAME: quansight/{{ cookiecutter.project_name }}-{{ '${{ matrix.dockerfile }}' }}
+          IMAGE_NAME: registry.digitalocean.com/{{ cookiecutter.project_name }}/qhub-{{ '${{ matrix.dockerfile }}' }}
         run: |
           docker build -f image/Dockerfile.{{ '${{ matrix.dockerfile }}' }} -t $IMAGE_NAME:$IMAGE_TAG image
           docker push $IMAGE_NAME:$IMAGE_TAG

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/do.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/do.tf
@@ -1,5 +1,10 @@
 provider "digitalocean" {}
 
+module "registry" {
+  source = "github.com/quansight/qhub-terraform-modules//modules/digitalocean/registry"
+  name   = "{{ cookiecutter.project_name }}"
+}
+
 
 module "kubernetes" {
   source = "github.com/quansight/qhub-terraform-modules//modules/digitalocean/kubernetes"


### PR DESCRIPTION
Due recent support added in qhub-terraform-modules https://github.com/Quansight/qhub-terraform-modules/pull/22

This is still a WIP need to find out how to automate https://www.digitalocean.com/docs/images/container-registry/quickstart/#use-images-in-your-registry-with-kubernetes