### PR TITLE
Fix terraform formatting issue with aws kubernetes.tf generation

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
@@ -11,7 +11,7 @@ module "kubernetes-initialization" {
   namespace = var.environment
   secrets   = []
   dependencies = [
-{% if cookiecutter.provider == "aws" -%}
+{% if cookiecutter.provider == "aws" %}
     module.kubernetes.depended_on
 {% endif %}
   ]


### PR DESCRIPTION
Causes downstream errors with generated terraform files. Need to add to qhub github-actions to do a formatting check #107 which will be in new PR