### PR TITLE
override colors

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,9 @@
+{# Import the theme's layout. #}
+{% extends '!layout.html' %}
+
+{%- block extrahead %}
+{{ super() }}
+<style>
+  .md-header, .md-tabs {background-color: #653c90}
+</style>
+{%- endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ NAVIGATION_LINKS = {
     DEFAULT_LANG: tuple(),
 }
 
-THEME_COLOR = "#652c90"  # "#7B699F"
+THEME_COLOR = "652c90"  # "#7B699F"
 
 POSTS = (
     ("posts/*.md", "posts", "post.tmpl"),
@@ -32,6 +32,8 @@ POSTS = (
     ("posts/*.ipynb", "posts", "post.tmpl"),
     ("posts/*.md.ipynb", "posts", "post.tmpl"),
 )
+
+templates_path = ['_templates']
 
 # Material theme options (see theme.conf for more information)
 html_theme_options = {


### PR DESCRIPTION
This PR adds a _templates folder with the ability to override the sphinx-material theme colors.

cc @dharhas @tonyfast 