### PR TITLE
[WIP] Add shared volume backup functionality

### DIFF
--- a/backup_files/Dockerfile
+++ b/backup_files/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3
+
+RUN pip install --upgrade pip && pip install --no-cache-dir fsspec gcsfs s3fs
+
+ADD backup_script.py /

--- a/backup_files/backup_script.py
+++ b/backup_files/backup_script.py
@@ -3,17 +3,39 @@ from datetime import datetime
 import os
 from fsspec import get_fs_token_paths
 import sys
+import json
 
 t = datetime.utcnow()
 
+try:
+    backup_bucket = sys.argv[1]  # Grabs bucket name command line argument
+except:
+    print("Missing command line arguments for bucket name. Backup not performed")
+    sys.exit(1)
+
+try:
+    cloud_provider = sys.argv[2]  # Sets the cloud provider type [aws, gcp, do]
+except:
+    print("Missing command line arguments for cloud provider. Backup not performed")
+    sys.exit(1)
+
 f_name = f"{t.strftime('%Y-%m-%d_%H-%M-%S')}_UTC_shared_nfs_backup.tar.gz"
+
+# Creates fsspec filesystem based on the envrinment variables of the indicated cloud provider
+if cloud_provider == "aws":
+    key = os.environ["AWS_ACCESS_KEY_ID"]
+    secret = os.environ["AWS_SECRET_ACCESS_KEY"]
+    creds = {"key": key, "secret": secret}
+    fs, _, _ = get_fs_token_paths(backup_bucket, storage_options=creds)
+
+if cloud_provider == "gcp":
+    creds = json.loads(os.environ["GOOGLE_CREDENTIALS"])
+    fs, _, _ = get_fs_token_paths(
+        backup_bucket, storage_options={"token": json.loads(creds)}
+    )
 
 os.system(
     f"tar -zcvf {f_name} ./shared_nfs/"
 )  # Tarballs the shared_nfs folder. This will keep permissions and groups
 
-backup_bucket = sys.argv[1]  # Grabs bucket name command line argument
-fs, _, _ = get_fs_token_paths(
-    backup_bucket, storage_options={"token": "cloud"}
-)  # creates an fs bucket
-fs.put(f_name, f"{backup_bucket}/{f_name}")
+fs.put(f_name, f"{backup_bucket}/{f_name}")  # Uploads backup file to cloud storage

--- a/backup_files/backup_script.py
+++ b/backup_files/backup_script.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+from datetime import datetime
+import os
+from fsspec import get_fs_token_paths
+import sys
+
+t = datetime.utcnow()
+
+f_name = f"{t.strftime('%Y-%m-%d_%H-%M-%S')}_UTC_shared_nfs_backup.tar.gz"
+
+os.system(
+    f"tar -zcvf {f_name} ./shared_nfs/"
+)  # Tarballs the shared_nfs folder. This will keep permissions and groups
+
+backup_bucket = sys.argv[1]  # Grabs bucket name command line argument
+fs, _, _ = get_fs_token_paths(
+    backup_bucket, storage_options={"token": "cloud"}
+)  # creates an fs bucket
+fs.put(f_name, f"{backup_bucket}/{f_name}")

--- a/backup_files/backup_spec.yaml
+++ b/backup_files/backup_spec.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: backup 
+  namespace: testing # Needs cookiecutter
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: backup-job
+    spec:
+      containers:
+        - name: backup-testing
+          image: quansight/qhub-backup:126c8eeddd7b
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: home
+              mountPath: /shared_nfs
+          command: ["/bin/sh"]
+          args: [ "-c", "python backup_script.py gs://qhub-datum-backup" ] 
+          # need way to specify backup bucket
+
+      volumes:
+      - name: home
+        persistentVolumeClaim:
+          claimName: nfs-mount-testing-share
+      restartPolicy: Never


### PR DESCRIPTION
Currently, this code only works on GCP

This yaml file will kick off a job that will tarball the shared nfs volume and upload it to Google Cloud Storage.

A similar yaml could be used to restore the volume. I've verified that using this tar command will keep all the groups and permissions of the files: `tar -xvf shared_backup.tar.gz --same-owner `