### PR TITLE
Jkellndorfer patch step by step guide 1

### DIFF
--- a/docs/docs/step-by-step-walkthrough.md
+++ b/docs/docs/step-by-step-walkthrough.md
@@ -9,7 +9,7 @@ This guide makes the following assumptions:
 Other providers can be used, but you will need consult their documention on setting up oauth and DNS registry.
 
 
-## Installing QHUB:
+## Installing QHub:
 
 * Via github:
 
@@ -24,9 +24,9 @@ Other providers can be used, but you will need consult their documention on sett
     pip install qhub
     ```
 
-## Deployment steps
+## Configuration
 
-1) **Environment variables**
+### 1) **Environment variables**
 
 Set the required environment variables based on your choice of provider:
 
@@ -41,13 +41,13 @@ Set the required environment variables based on your choice of provider:
 
 After this step, you are ready to initialize `QHub`
 
-2) **DNS: Optionally Create a Cloudflare account**
+### 2) **DNS: Optionally Create a Cloudflare account**
     
 This step is necessary if you don't have a DNS with an existing domain for which you can make `CNAME` or `A` entries.
 
 To set up your DNS and automatically get a certificate, you can create a [Cloudflare][Cloudflare_signup] account and register a [domain name]. 
 
-3) **Configure QHub**
+### 3) **Initialize and Configure QHub**
 
 In your terminal, where the environment variables from Step **1** are set, enter the command `qhub init` followed by the abbreviation of your cloud provider. (do: Digital Ocean, aws: Amazon Web Services, gcp: Google Cloud Platform). This will create  a `qhub-config.yaml` file in your folder.
 
@@ -115,7 +115,7 @@ Lastly, make the adjusted changes to configure your cluster in he cloud provider
         kubernetes_version: 1.18.8-do.1
     
 
-4) Render QHub
+### 4) Render QHub
     
 The render step will use `qhub_config.yaml` as a template to create an output folder and generate all the necessary files for deployement. 
     
@@ -131,7 +131,7 @@ The render step will use `qhub_config.yaml` as a template to create an output fo
         $ mv qhub_config.yaml qhub-deployment/
     
 
-5) Deployment and DNS registry
+## 4) Deployment and DNS registry
 
 The following script will check environment variables, deploy the infrastructure, and prompt for DNS registry
     ```
@@ -160,7 +160,7 @@ The following script will check environment variables, deploy the infrastructure
     Press **Enter** when the DNS is registered to complete the deployment
 
 
-6) **Set up  github repository**
+## 5) **Set up  github repository**
 
     Create a github personal access token ([github_access_token]) and check the `repo` and `workflow` options under scopes.
 
@@ -177,7 +177,7 @@ The following script will check environment variables, deploy the infrastructure
     $ git push origin master
     ```
 
-7) **Git ops enabled**
+## 6) **Git ops enabled**
     Since the infrastructure state is reflected in the repository, it allows self-documenting of infrastructure and team members to submit pull requests that can be reviewed before modifying the infrastructure.
 
     To use gitops, make a change to the `qhub-ops.yaml` in a new branch and create pull request into master. When the pull request is merged, it will trigger a deployement of all of those changes to your qhub.

--- a/docs/docs/step-by-step-walkthrough.md
+++ b/docs/docs/step-by-step-walkthrough.md
@@ -24,9 +24,9 @@ Other providers can be used, but you will need consult their documention on sett
     pip install qhub
     ```
 
-## 2) Configuration
+## 2. Configuration
 
-### 2.1) **Environment variables**
+### 2.1. **Environment variables**
 
 Set the required environment variables based on your choice of provider:
 
@@ -41,13 +41,13 @@ Set the required environment variables based on your choice of provider:
 
 After this step, you are ready to initialize `QHub`
 
-### 2.2) **DNS: Optionally Create a Cloudflare account**
+### 2.2. **DNS: Optionally Create a Cloudflare account**
     
 This step is necessary if you don't have a DNS with an existing domain for which you can make `CNAME` or `A` entries.
 
 To set up your DNS and automatically get a certificate, you can create a [Cloudflare][Cloudflare_signup] account and register a [domain name]. 
 
-### 2.3) **Initialize and Configure QHub**
+### 2.3. **Initialize and Configure QHub**
 
 In your terminal, where the environment variables from Step **1** are set, enter the command `qhub init` followed by the abbreviation of your cloud provider. (do: Digital Ocean, aws: Amazon Web Services, gcp: Google Cloud Platform). This will create  a `qhub-config.yaml` file in your folder.
 
@@ -115,7 +115,7 @@ Lastly, make the adjusted changes to configure your cluster in he cloud provider
         kubernetes_version: 1.18.8-do.1
     
 
-### 2.4) Render QHub
+### 2.4. Render QHub
     
 The render step will use `qhub_config.yaml` as a template to create an output folder and generate all the necessary files for deployement. 
     
@@ -131,7 +131,7 @@ The render step will use `qhub_config.yaml` as a template to create an output fo
         $ mv qhub_config.yaml qhub-deployment/
     
 
-## 3) Deployment and DNS registry
+## 3. Deployment and DNS registry
 
 The following script will check environment variables, deploy the infrastructure, and prompt for DNS registry
     ```
@@ -160,7 +160,7 @@ The following script will check environment variables, deploy the infrastructure
     Press **Enter** when the DNS is registered to complete the deployment
 
 
-## 4) **Set up  github repository**
+## 4. **Set up  github repository**
 
     Create a github personal access token ([github_access_token]) and check the `repo` and `workflow` options under scopes.
 
@@ -177,7 +177,7 @@ The following script will check environment variables, deploy the infrastructure
     $ git push origin master
     ```
 
-## 5) **Git ops enabled**
+## 5. **Git ops enabled**
     Since the infrastructure state is reflected in the repository, it allows self-documenting of infrastructure and team members to submit pull requests that can be reviewed before modifying the infrastructure.
 
     To use gitops, make a change to the `qhub-ops.yaml` in a new branch and create pull request into master. When the pull request is merged, it will trigger a deployement of all of those changes to your qhub.

--- a/docs/docs/step-by-step-walkthrough.md
+++ b/docs/docs/step-by-step-walkthrough.md
@@ -1,34 +1,61 @@
 # Step by Step QHub Cloud Deployment
 
 This guide makes the following assumptions:
+
 - [Github actions] will be used for CICD
-- Oauth will be [via github]using [auth0]
+- Oauth will be [via github] using [auth0]
 - DNS registry will be through [Cloudflare]
 
 Other providers can be used, but you will need consult their documention on setting up oauth and DNS registry.
 
+
+## Installing QHUB:
+
+* Via github:
+
+    git clone git@github.com:Quansight/qhub.git
+    cd qhub
+    python ./setup.py install
+
+* Via pip:
+
+    pip install qhub
+
+
 ## Deployment steps
+
 1) **Environment variables**
 
-    Set the required environment variables based on your choice of provider below:
+Set the required environment variables based on your choice of provider:
 
-- [AWS Environment Variables]
+- AWS:    (Old instructions for reference: [AWS Environment Variables])
+    
+    * `AWS_ACCESS_KEY_ID`
+    * `AWS_SECRET_ACCESS_KEY`
+    * `AWS_DEFAULT_REGION`
+
 - [Digital Ocean Environment Variables]
 - [Google Cloud Platform]
 
-    After this step, you are ready to initialize `QHub`
+After this step, you are ready to initialize `QHub`
 
-2) **Create Cloudflare account**
-    To set up your DNS and automatically get a certificate, you will need to create a [Cloudflare][Cloudflare_signup] account and register a [domain name]. 
+2) **DNS: Optionally Create a Cloudflare account**
+    
+This step is necessary if you don't have a DNS with an existing domain for which you can make `CNAME` or `A` entries.
+
+To set up your DNS and automatically get a certificate, you can create a [Cloudflare][Cloudflare_signup] account and register a [domain name]. 
 
 3) **Configure QHub**
-    In your terminal, enter the command `qhub init` followed by the abbreviation of your cloud provider. (do: Digital Ocean, aws: Amazon Web Services, gcp: Google Cloud Platform). This will create  a `qhub-config.yaml` file in your folder.
+
+In your terminal, where the environment variables from Step **1** are set, enter the command `qhub init` followed by the abbreviation of your cloud provider. (do: Digital Ocean, aws: Amazon Web Services, gcp: Google Cloud Platform). This will create  a `qhub-config.yaml` file in your folder.
     ```
-    $ qhub init do
+    $ qhub init do    # Digital Ocean
+    $ qhub init aws   # Amazon Web Services
+    $ qhub init gcp   # Google Cloud Platform
     ```
      
 
-    Open the config file, and under the `security` section, add your github usernames and set a unique `uid` for each username.
+Open the config file, and under the `security` section, add your *github usernames* (or those used with `oauth`), set a unique `uid` for each username, and set `primary_group` and optionally `secondary_groups` affiliations for the user:
          
      ```
     costrouc:
@@ -38,24 +65,26 @@ Other providers can be used, but you will need consult their documention on sett
             - billing
     ``` 
 
-    Set the `domain` field on top of the config file to a domain you own in Cloudflare. 
+Set the `domain` field on top of the config file to a domain or sub-domain you own in Cloudflare or your existing DNS, e.g. `testing.qhub.dev`: 
 
      ```
     domain: testing.qhub.dev
     ``` 
-    Create an [oauth application] in github and fill in the client_id and client_secret.
+
+Create an [oauth application] in github and fill in the client_id and client_secret.
          
      ```
     client_id: "7b88..."
     client_secret: "8edd7f14..."
     ```
     
-    Set the `oauth_callback_url` by prepending your domain with `jupyter` and appending `/hub/oauth_callback`. 
+Set the `oauth_callback_url` by prepending your domain with `jupyter` and appending `/hub/oauth_callback`. Example:
+ 
     ```
     oauth_callback_url: https://jupyter.testing.qhub.dev/hub/oauth_callback
     ```
 
-    **(Digital Ocean only)**
+**(Digital Ocean only)**
     
     If your provider is Digital Ocean you will need to install [doctl] and obtain the latest kubernetes version. After installing, run this terminal command:
         
@@ -74,12 +103,12 @@ Other providers can be used, but you will need consult their documention on sett
 
 4) Render QHub
     
-    The render step will use `qhub_config.yaml` as a template to create an output folder and generate all the necessary files for deployement. 
+The render step will use `qhub_config.yaml` as a template to create an output folder and generate all the necessary files for deployement. 
     
     The below example will create the directory `qhub-deployment` and fill it with the necessary files.
 
     ```
-    $ qhub-render -c qhub qhub_config.yaml -o qhub-deployment -f
+    $ qhub render -c qhub_config.yaml -o qhub-deployment -f
     ```
     
     Move the config file into the output directory

--- a/docs/docs/step-by-step-walkthrough.md
+++ b/docs/docs/step-by-step-walkthrough.md
@@ -57,51 +57,63 @@ In your terminal, where the environment variables from Step **1** are set, enter
         $ qhub init gcp   # Google Cloud Platform
      
 
-Open the config file, and under the `security` section, add your and optionally other `github usernames` (or the usernames used with your `oauth` application), set a unique `uid` for each username, and set `primary_group` and optionally `secondary_groups` affiliations for the user:
-         
-     ```
-    costrouc:
-        uid: 1000
-        primary_group: users
-        secondary_groups:
-            - billing
-    ``` 
+Open the config file `qhub-config.yaml` for editing.
+
+- Top section:
+
+Chose a `project_name` that is a compliant name. E.g. a valid bucket name for AWS.
+
+        project_name: my-jupyterhub
 
 Set the `domain` field on top of the config file to a domain or sub-domain you own in Cloudflare or your existing DNS, e.g. `testing.qhub.dev`: 
 
-     ```
-    domain: testing.qhub.dev
-    ``` 
+        domain: testing.qhub.dev
+        
+- `security` section:
 
 Create an [oauth application] in github and fill in the client_id and client_secret.
-         
-     ```
-    client_id: "7b88..."
-    client_secret: "8edd7f14..."
-    ```
-    
+             
+        client_id: "7b88..."
+        client_secret: "8edd7f14..."
+      
 Set the `oauth_callback_url` by prepending your domain with `jupyter` and appending `/hub/oauth_callback`. Example:
- 
-    ```
-    oauth_callback_url: https://jupyter.testing.qhub.dev/hub/oauth_callback
-    ```
+    
+        oauth_callback_url: https://jupyter.testing.qhub.dev/hub/oauth_callback
+
+Add your and optionally other `github username(s)` (or the usernames used with your `oauth` application), set a unique `uid` for each username, and set `primary_group` and optionally `secondary_groups` affiliations for the user:
+         
+
+        costrouc:
+            uid: 1000000
+            primary_group: users
+            secondary_groups:
+                - billing
+                - admin
+       janeuser:
+            uid: 1000001
+            primary_group: users
+             
+- Cloud provider section:
+
+Lastly, make the adjusted changes to configure your cluster in he cloud provider section.
+
 
 **(Digital Ocean only)**
     
     If your provider is Digital Ocean you will need to install [doctl] and obtain the latest kubernetes version. After installing, run this terminal command:
         
-    ```
-    $ doctl kubernetes options versions
-    Slug            Kubernetes Version
-    1.18.8-do.1     1.18.8
-    1.17.11-do.1    1.17.11
-    1.16.14-do.1    1.16.14
-    ```
+    
+        $ doctl kubernetes options versions
+        Slug            Kubernetes Version
+        1.18.8-do.1     1.18.8
+        1.17.11-do.1    1.17.11
+        1.16.14-do.1    1.16.14
+   
     
     Copy the first line under `Slug` which is the latest version. Enter it into the `kubernetes_version` under the `digital_ocean` section of your config file. 
-    ```
-    kubernetes_version: 1.18.8-do.1
-    ```
+    
+        kubernetes_version: 1.18.8-do.1
+    
 
 4) Render QHub
     
@@ -109,18 +121,19 @@ The render step will use `qhub_config.yaml` as a template to create an output fo
     
     The below example will create the directory `qhub-deployment` and fill it with the necessary files.
 
-    ```
-    $ qhub render -c qhub_config.yaml -o qhub-deployment -f
-    ```
+    
+        $ qhub render -c qhub_config.yaml -o qhub-deployment -f
+    
     
     Move the config file into the output directory
         
-    ```
-    $ mv qhub_config.yaml qhub-deployment/
-    ```
+    
+        $ mv qhub_config.yaml qhub-deployment/
+    
 
-5) **Deployment and DNS registry**
-    The following script will check environment variables, deploy the infrastructure, and prompt for DNS registry
+5) Deployment and DNS registry
+
+The following script will check environment variables, deploy the infrastructure, and prompt for DNS registry
     ```
     $ python scripts/00-guided-install.py
     Ensure that oauth settings are in configuration [Press \"Enter\" to continue]

--- a/docs/docs/step-by-step-walkthrough.md
+++ b/docs/docs/step-by-step-walkthrough.md
@@ -9,7 +9,7 @@ This guide makes the following assumptions:
 Other providers can be used, but you will need consult their documention on setting up oauth and DNS registry.
 
 
-## Installing QHub:
+## 1) Installing QHub:
 
 * Via github:
 
@@ -24,9 +24,9 @@ Other providers can be used, but you will need consult their documention on sett
     pip install qhub
     ```
 
-## Configuration
+## 2) Configuration
 
-### 1) **Environment variables**
+### 2.1) **Environment variables**
 
 Set the required environment variables based on your choice of provider:
 
@@ -41,13 +41,13 @@ Set the required environment variables based on your choice of provider:
 
 After this step, you are ready to initialize `QHub`
 
-### 2) **DNS: Optionally Create a Cloudflare account**
+### 2.2) **DNS: Optionally Create a Cloudflare account**
     
 This step is necessary if you don't have a DNS with an existing domain for which you can make `CNAME` or `A` entries.
 
 To set up your DNS and automatically get a certificate, you can create a [Cloudflare][Cloudflare_signup] account and register a [domain name]. 
 
-### 3) **Initialize and Configure QHub**
+### 2.3) **Initialize and Configure QHub**
 
 In your terminal, where the environment variables from Step **1** are set, enter the command `qhub init` followed by the abbreviation of your cloud provider. (do: Digital Ocean, aws: Amazon Web Services, gcp: Google Cloud Platform). This will create  a `qhub-config.yaml` file in your folder.
 
@@ -115,7 +115,7 @@ Lastly, make the adjusted changes to configure your cluster in he cloud provider
         kubernetes_version: 1.18.8-do.1
     
 
-### 4) Render QHub
+### 2.4) Render QHub
     
 The render step will use `qhub_config.yaml` as a template to create an output folder and generate all the necessary files for deployement. 
     
@@ -131,7 +131,7 @@ The render step will use `qhub_config.yaml` as a template to create an output fo
         $ mv qhub_config.yaml qhub-deployment/
     
 
-## 4) Deployment and DNS registry
+## 3) Deployment and DNS registry
 
 The following script will check environment variables, deploy the infrastructure, and prompt for DNS registry
     ```
@@ -160,7 +160,7 @@ The following script will check environment variables, deploy the infrastructure
     Press **Enter** when the DNS is registered to complete the deployment
 
 
-## 5) **Set up  github repository**
+## 4) **Set up  github repository**
 
     Create a github personal access token ([github_access_token]) and check the `repo` and `workflow` options under scopes.
 
@@ -177,7 +177,7 @@ The following script will check environment variables, deploy the infrastructure
     $ git push origin master
     ```
 
-## 6) **Git ops enabled**
+## 5) **Git ops enabled**
     Since the infrastructure state is reflected in the repository, it allows self-documenting of infrastructure and team members to submit pull requests that can be reviewed before modifying the infrastructure.
 
     To use gitops, make a change to the `qhub-ops.yaml` in a new branch and create pull request into master. When the pull request is merged, it will trigger a deployement of all of those changes to your qhub.

--- a/docs/docs/step-by-step-walkthrough.md
+++ b/docs/docs/step-by-step-walkthrough.md
@@ -51,11 +51,10 @@ To set up your DNS and automatically get a certificate, you can create a [Cloudf
 
 In your terminal, where the environment variables from Step **1** are set, enter the command `qhub init` followed by the abbreviation of your cloud provider. (do: Digital Ocean, aws: Amazon Web Services, gcp: Google Cloud Platform). This will create  a `qhub-config.yaml` file in your folder.
 
-    ```
-    $ qhub init do    # Digital Ocean
-    $ qhub init aws   # Amazon Web Services
-    $ qhub init gcp   # Google Cloud Platform
-    ```
+
+        $ qhub init do    # Digital Ocean
+        $ qhub init aws   # Amazon Web Services
+        $ qhub init gcp   # Google Cloud Platform
      
 
 Open the config file, and under the `security` section, add your and optionally other `github usernames` (or the usernames used with your `oauth` application), set a unique `uid` for each username, and set `primary_group` and optionally `secondary_groups` affiliations for the user:

--- a/docs/docs/step-by-step-walkthrough.md
+++ b/docs/docs/step-by-step-walkthrough.md
@@ -197,3 +197,4 @@ The following script will check environment variables, deploy the infrastructure
 [doctl]: https://www.digitalocean.com/docs/apis-clis/doctl/how-to/install/
 [oauth application]: https://docs.github.com/en/free-pro-team@latest/developers/apps/authorizing-oauth-apps
 [recording your DNS]: https://support.cloudflare.com/hc/en-us/articles/360019093151-Managing-DNS-records-in-Cloudflare
+

--- a/docs/docs/step-by-step-walkthrough.md
+++ b/docs/docs/step-by-step-walkthrough.md
@@ -89,7 +89,7 @@ Add your and optionally other `github username(s)` (or the usernames used with y
             secondary_groups:
                 - billing
                 - admin
-       janeuser:
+        janeuser:
             uid: 1000001
             primary_group: users
              

--- a/docs/docs/step-by-step-walkthrough.md
+++ b/docs/docs/step-by-step-walkthrough.md
@@ -13,14 +13,16 @@ Other providers can be used, but you will need consult their documention on sett
 
 * Via github:
 
+    ```
     git clone git@github.com:Quansight/qhub.git
     cd qhub
     python ./setup.py install
+    ```
 
 * Via pip:
-
+    ```
     pip install qhub
-
+    ```
 
 ## Deployment steps
 
@@ -48,6 +50,7 @@ To set up your DNS and automatically get a certificate, you can create a [Cloudf
 3) **Configure QHub**
 
 In your terminal, where the environment variables from Step **1** are set, enter the command `qhub init` followed by the abbreviation of your cloud provider. (do: Digital Ocean, aws: Amazon Web Services, gcp: Google Cloud Platform). This will create  a `qhub-config.yaml` file in your folder.
+
     ```
     $ qhub init do    # Digital Ocean
     $ qhub init aws   # Amazon Web Services
@@ -55,7 +58,7 @@ In your terminal, where the environment variables from Step **1** are set, enter
     ```
      
 
-Open the config file, and under the `security` section, add your *github usernames* (or those used with `oauth`), set a unique `uid` for each username, and set `primary_group` and optionally `secondary_groups` affiliations for the user:
+Open the config file, and under the `security` section, add your and optionally other `github usernames` (or the usernames used with your `oauth` application), set a unique `uid` for each username, and set `primary_group` and optionally `secondary_groups` affiliations for the user:
          
      ```
     costrouc:


### PR DESCRIPTION
Here are some proposed changes. Foremost I thought the "scripts" reference was not necessary since config and deployment is handled nicely with "qhub render" and "qhub deploy". Tried to also make it more generic for other DNS services and be a little more prescriptive of how to use AWS vs DO/GCP. And since it's October, and the PR is accepted, I guess there is the Hacktoberfest merit possible...