### PR TITLE
Fix bug in `initialize.py`

### DIFF
--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -211,7 +211,7 @@ def render_config(
             config["security"]["authentication"]["config"]["client_id"] = input(
                 "Github client_id: "
             )
-            config["security"]["authentication"]["config"]["client_id"] = input(
+            config["security"]["authentication"]["config"]["client_secret"] = input(
                 "Github client_secret: "
             )
             config["security"]["authentication"]["config"][


### PR DESCRIPTION
The GitHub client secret wasn't saved because of a bug: probably a copy and paste error.