### PR TITLE
[WIP] Restrict spawn to users in a group 

### DIFF
--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -236,6 +236,7 @@ class CDSDashboards(Base):
     enabled: bool
     cds_hide_user_named_servers: typing.Optional[bool]
     cds_hide_user_dashboard_servers: typing.Optional[bool]
+    spawn_allow_group: typing.Optional[str]
 
 
 # ==================== Main ===================

--- a/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterhub/environment.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterhub/environment.yaml
@@ -10,4 +10,4 @@ dependencies:
  - cdsdashboards>=0.5.3
  - pip:
    - jupyterhub-kubespawner >= 0.16.1
-   - qhub-jupyterhub-theme >= 0.3.1
+   - qhub-jupyterhub-theme >= 0.3.2

--- a/qhub/template/{{ cookiecutter.repo_directory }}/templates/jupyterhub_config.py.j2
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/templates/jupyterhub_config.py.j2
@@ -1,16 +1,22 @@
+{% set dashboards_restricted = cookiecutter.cdsdashboards.spawn_allow_group is defined and cookiecutter.cdsdashboards.spawn_allow_group %}
+
 {% if cookiecutter.cdsdashboards.enabled %}
 
 # ================ CDSDASHBOARDS =====================
 c.JupyterHub.allow_named_servers = True
 from cdsdashboards.hubextension import cds_extra_handlers
 c.JupyterHub.extra_handlers = cds_extra_handlers
-from cdsdashboards.app import CDS_TEMPLATE_PATHS
-c.JupyterHub.template_paths = CDS_TEMPLATE_PATHS
+from cdsdashboards.app import CDS_TEMPLATE_PATHS{% if dashboards_restricted %}_RESTRICTED{% endif %}
+c.JupyterHub.template_paths = CDS_TEMPLATE_PATHS{% if dashboards_restricted %}_RESTRICTED{% endif %}
 c.JupyterHub.spawner_class = 'cdsdashboards.hubextension.spawners.variablekube.VariableKubeSpawner'
 c.CDSDashboardsConfig.builder_class = 'cdsdashboards.builder.kubebuilder.KubeBuilder'
 c.VariableMixin.default_presentation_cmd = ['python3', '-m', 'jhsingle_native_proxy.main']
 
-c.JupyterHub.default_url = '/hub/home'
+{% if dashboards_restricted %}
+c.CDSDashboardsConfig.spawn_allow_group = 'spawners-group'
+{% endif %}
+
+c.JupyterHub.default_url = '/hub/home{% if dashboards_restricted %}-cds{% endif %}'
 
 {% else %}
 
@@ -44,6 +50,9 @@ c.JupyterHub.template_vars = {
     {% endif %}
     {% if cookiecutter.cdsdashboards.cds_hide_user_dashboard_servers is defined %}
     "cds_hide_user_dashboard_servers": {{ cookiecutter.cdsdashboards.cds_hide_user_dashboard_servers }},
+    {% endif %}
+    {% if dashboards_restricted %}
+    "cdsdashboards_restricted": True,
     {% endif %}
 {% endif %}
 }


### PR DESCRIPTION
Would solve part of #454.
So far, can add:

```
cdsdashboards:
  enabled: true
  spawn_allow_group: spawners-group
```

This restricts JupyterLab spawn to only members of spawners-group (a JH group). We need to:

1. Ensure members can be easily added to this group via Auth0 if possible
2. Restrict access to Dask Gateway too
3. 