### PR TITLE
Adding field to configure the branch being used for CI/CD

### DIFF
--- a/docs/source/02_get_started/04_configuration.md
+++ b/docs/source/02_get_started/04_configuration.md
@@ -13,7 +13,6 @@ be accurate.
 project_name: do-jupyterhub # name of the kubernetes/Cloud deployment 
 namespace: dev
 provider: <provider_alias> # determines the choice of cloud provider for the deployment
-ci_cd: github-actions # continuous integration and continuous deployment framework to use
 domain: "do.qhub.dev" # top level URL exposure to monitor JupyterLab
 ```
 
@@ -29,13 +28,25 @@ domain: "do.qhub.dev" # top level URL exposure to monitor JupyterLab
     Amazon AWS, `gcp` for Google Could Provider, `azure` for Microsoft
     Azure, and `local` for a local or existing kubernetes deployment.
 
- - `ci_cd`: is the continuous integration and continuous deployment
-   framework to use. Currently only `github-actions` is supported.
-
  - `domain`: is the top level URL to put JupyterLab and future
    services under such a monitoring. For example `jupyter.qhub.dev`
    would be the domain for JupyterHub to be exposed under. Note that
    this domain does not have to have `jupyter` in it.
+
+## Continuous Integration and Continuous Deployment
+
+`ci_cd`: is the continuous integration and continuous deployment
+framework to use. QHub uses infrastructure as code to allow developers
+and users of QHub to request change to the environment via PRs which
+then get approved by administration. Currently only `github-actions`
+is supported. You may configure the branch that github-actions watches
+for pull requests and commits.
+
+```yaml
+ci_cd:
+  type: github-actions
+  branch: main
+```
 
 ## Certificate
 
@@ -682,8 +693,11 @@ Everything in the configuration is set besides [???]
 ```yaml
 project_name: do-jupyterhub
 provider: do
-ci_cd: github-actions
 domain: "do.qhub.dev"
+
+ci_cd: 
+  type: github-actions
+  branch: main
 
 certificate:
   type: self-signed

--- a/docs/source/04_how_to_guides/1_qhub-aws-deploy_guide.md
+++ b/docs/source/04_how_to_guides/1_qhub-aws-deploy_guide.md
@@ -14,8 +14,10 @@ This section allows setting up the general information about your project.
 
 ```yaml
 project_name: qhub-aws-deployment
+ci_cd:
+  type: github-actions
+  branch: main
 provider: aws
-ci_cd: github-actions
 domain: "aws.qhub.dev"
 ```
 
@@ -23,7 +25,7 @@ domain: "aws.qhub.dev"
 
 * `provider` specifies which cloud provider to use for the deployment. For AWS, you will write `aws`. Other options include `do` for Digital Ocean and `gcp` for Google Cloud Platform.
 
-* `ci_cd` refers to the continuous integration and continuous deployment framework to use. Currently, [github-actions](https://help.github.com/en/actions) is the supported framework.
+* `ci_cd` refers to the continuous integration and continuous deployment framework to use. Currently, [github-actions](https://help.github.com/en/actions) is the supported framework. The `branch` parameter allow the user to control the main branch that is watched for PRs and commits.
 
 * `domain` is the top level url to put qhub and future services under such a monitoring. In this example, `aws.qhub.dev` would be the domain for qhub to be exposed under.
 

--- a/docs/source/04_how_to_guides/2_qhub-gcp-deploy_guide.md
+++ b/docs/source/04_how_to_guides/2_qhub-gcp-deploy_guide.md
@@ -15,7 +15,9 @@ This section allows setting up the general information about your project.
 ```yaml
 project_name: qhub-gcp-deployment
 provider: gcp
-ci_cd: github-actions
+ci_cd:
+  type: github-actions
+  branch: main
 domain: "gcp.qhub.dev"
 ```
 
@@ -23,7 +25,7 @@ domain: "gcp.qhub.dev"
 
 * `provider` specifies which cloud provider to use for the deployment. For GCP, you will write `gcp`. Possible options include `do` for Digital Ocean and `aws` for Amazon Web Services.
 
-* `ci_cd` refers to the continuous integration and continuous deployment framework to use. Currently, [github-actions](https://help.github.com/en/actions) is the supported framework.
+* `ci_cd` refers to the continuous integration and continuous deployment framework to use. Currently, [github-actions](https://help.github.com/en/actions) is the supported framework. The `branch` parameter allow the user to control the main branch that is watched for PRs and commits.
 
 * `domain` is the top level url to put qhub and future services under such a monitoring. In this example, `gcp.qhub.dev` would be the domain for qhub to be exposed under.
 

--- a/docs/source/04_how_to_guides/3_qhub-do-deploy_guide.md
+++ b/docs/source/04_how_to_guides/3_qhub-do-deploy_guide.md
@@ -16,7 +16,9 @@ This section allows setting up the general information about your project.
 ```yaml
 project_name: qhub-do-deployment
 provider: do
-ci_cd: github-actions
+ci_cd:
+  type: github-actions
+  branch: main
 domain: "do.qhub.dev"
 ```
 
@@ -24,7 +26,7 @@ domain: "do.qhub.dev"
 
 * `provider` specifies which cloud provider to use for the deployment. For Digital Ocean, you will write `do`. Other options include `aws` for Amazon Web Services and `gcp` for Google Cloud Platform.
 
-* `ci_cd` refers to the continuous integration and continuous deployment framework to use. Currently, [github-actions](https://help.github.com/en/actions) is the supported framework.
+* `ci_cd` refers to the continuous integration and continuous deployment framework to use. Currently, [github-actions](https://help.github.com/en/actions) is the supported framework. The `branch` parameter allow the user to control the main branch that is watched for PRs and commits.
 
 * `domain` is the top level url to put qhub and future services under such a monitoring. In this example, `do.qhub.dev` would be the domain for qhub to be exposed under.
 

--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -17,7 +17,10 @@ from qhub.provider.cloud import digital_ocean
 BASE_CONFIGURATION = {
     "project_name": None,
     "provider": None,
-    "ci_cd": None,
+    "ci_cd": {
+        "type": "PLACEHOLDER",
+        "branch": "main",
+    },
     "domain": None,
     "certificate": {
         "type": "self-signed",
@@ -237,7 +240,7 @@ def render_config(
 ):
     config = BASE_CONFIGURATION
     config["provider"] = cloud_provider
-    config["ci_cd"] = ci_provider
+    config["ci_cd"]["type"] = ci_provider
 
     if terraform_state is not None:
         config["terraform_state"] = {"type": terraform_state}

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -42,6 +42,14 @@ class Base(pydantic.BaseModel):
         extra = "forbid"
 
 
+# ============== CI/CD =============
+
+
+class CICD(Base):
+    type: CiEnum = "github-actions"
+    branch: str = "main"
+
+
 # ============= Terraform ===============
 
 
@@ -247,7 +255,7 @@ class Main(Base):
     project_name: letter_dash_underscore_regex
     namespace: typing.Optional[letter_dash_underscore_regex]
     provider: ProviderEnum
-    ci_cd: CiEnum
+    ci_cd: CICD
     domain: str
     terraform_state: typing.Optional[TerraformState]
     terraform_modules: typing.Optional[TerraformModules]

--- a/qhub/template/cookiecutter.json
+++ b/qhub/template/cookiecutter.json
@@ -3,7 +3,10 @@
     "project_name": null,
     "namespace": "dev",
     "provider": null,
-    "ci_cd": null,
+    "ci_cd": {
+      "type": "github-actions",
+      "branch": "main"
+    },
     "endpoint": null,
     "terraform_version": "0.14.9",
     "terraform_state": {

--- a/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/image-pr.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/image-pr.yaml
@@ -3,7 +3,7 @@ name: "Docker Image Build - Pull Request"
 on:
   pull_request:
     branches:
-      - master
+      - "{{ cookiecutter.ci_cd.branch }}"
     paths:
       - "image/**"
       - ".github/workflows/image-pr.yaml"

--- a/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/image.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/image.yaml
@@ -3,7 +3,7 @@ name: "Docker Image Build"
 on:
   push:
     branches:
-      - master
+      - "{{ cookiecutter.ci_cd.branch }}"
     paths:
       - "image/**"
       - ".github/workflows/image.yaml"


### PR DESCRIPTION
This feature was run into with the recent change of github to use `main` as the default branch. Additionally I'd really like to simplify our IIAC github-actions code to make it easier to port to other ci providers (e.g. gitlab)