### PR TITLE
Force 'git init' branch to be main

### DIFF
--- a/qhub/provider/git.py
+++ b/qhub/provider/git.py
@@ -14,6 +14,8 @@ def initialize_git(path=None):
     path = path or os.getcwd()
     with change_directory(path):
         subprocess.check_output(["git", "init"])
+        # Ensure initial branch is called main
+        subprocess.check_output(["git", "checkout", "-b", "main"])
 
 
 def add_git_remote(remote_path, path=None, remote_name="origin"):


### PR DESCRIPTION
Small change to "git checkout -b main" after "git init". This is to overcome some problems seen in auto-provisioned GitHub repos where the branch is really master... or do we actually still want 'master' for new repos anyway?

