### PR TITLE
AWS_DEFAULT_REGION respected, and availibility zones not needed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,13 +72,13 @@ jobs:
         if: ${{ matrix.provider != 'local' }}
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: 0.13.5
+          tf_actions_version: 0.14.9
           tf_actions_subcommand: 'fmt'
           tf_actions_working_dir: 'qhub-${{ matrix.provider }}-deployment/terraform-state'
       - name: 'Terraform Format'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: 0.13.5
+          tf_actions_version: 0.14.9
           tf_actions_subcommand: 'fmt'
           tf_actions_working_dir: 'qhub-${{ matrix.provider }}-deployment/infrastructure'
       - name: QHub Render Artifact

--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -344,8 +344,8 @@ def render_config(
             "hub_subtitle"
         ] = "Autoscaling Compute Environment on Amazon Web Services"
         config["amazon_web_services"] = AMAZON_WEB_SERVICES
-        if 'AWS_DEFAULT_REGION' in os.environ:
-            config["amazon_web_services"]['region'] = os.environ['AWS_DEFAULT_REGION']
+        if "AWS_DEFAULT_REGION" in os.environ:
+            config["amazon_web_services"]["region"] = os.environ["AWS_DEFAULT_REGION"]
         if kubernetes_version:
             config["amazon_web_services"]["kubernetes_version"] = kubernetes_version
     elif cloud_provider == "local":

--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -148,7 +148,6 @@ AZURE = {
 
 AMAZON_WEB_SERVICES = {
     "region": "us-west-2",
-#    "availability_zones": ["us-west-2a", "us-west-2b"],
     "kubernetes_version": "1.18",
     "node_groups": {
         "general": {"instance": "m5.large", "min_nodes": 1, "max_nodes": 1},

--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -148,7 +148,7 @@ AZURE = {
 
 AMAZON_WEB_SERVICES = {
     "region": "us-west-2",
-    "availability_zones": ["us-west-2a", "us-west-2b"],
+#    "availability_zones": ["us-west-2a", "us-west-2b"],
     "kubernetes_version": "1.18",
     "node_groups": {
         "general": {"instance": "m5.large", "min_nodes": 1, "max_nodes": 1},
@@ -345,6 +345,8 @@ def render_config(
             "hub_subtitle"
         ] = "Autoscaling Compute Environment on Amazon Web Services"
         config["amazon_web_services"] = AMAZON_WEB_SERVICES
+        if 'AWS_DEFAULT_REGION' in os.environ:
+            config["amazon_web_services"]['region'] = os.environ['AWS_DEFAULT_REGION']
         if kubernetes_version:
             config["amazon_web_services"]["kubernetes_version"] = kubernetes_version
     elif cloud_provider == "local":

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -164,7 +164,7 @@ class AzureProvider(Base):
 
 class AmazonWebServicesProvider(Base):
     region: str
-    availability_zones: typing.List[str]
+    availability_zones: typing.Optional[typing.List[str]]
     kubernetes_version: str
     node_groups: typing.Dict[str, NodeGroup]
 

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/aws.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/aws.tf
@@ -2,6 +2,12 @@ provider "aws" {
   region = "{{ cookiecutter.amazon_web_services.region }}"
 }
 
+data "aws_availability_zones" "awszones" {
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 # ==================== ACCOUNTING ======================
 module "accounting" {
@@ -33,7 +39,7 @@ module "network" {
   }
 
   vpc_cidr_block         = var.vpc_cidr_block
-  aws_availability_zones = var.availability_zones
+  aws_availability_zones = length(var.availability_zones) >= 2 ? var.availability_zones : [data.aws_availability_zones.awszones.names[0], data.aws_availability_zones.awszones.names[1]]
 }
 
 

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/variables.tf
@@ -18,9 +18,9 @@ variable "availability_zones" {
   description = "AWS availability zones within AWS region"
   type        = list(string)
 {% if cookiecutter.amazon_web_services.availability_zones is defined %}
-  default     = {{ cookiecutter.amazon_web_services.availability_zones | jsonify }}
+  default = {{ cookiecutter.amazon_web_services.availability_zones | jsonify }}
 {% else %}
-  default     = []
+  default = []
 {% endif %}
 }
 

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/variables.tf
@@ -17,11 +17,11 @@ variable "region" {
 variable "availability_zones" {
   description = "AWS availability zones within AWS region"
   type        = list(string)
-  {% if cookiecutter.amazon_web_services.availability_zones is defined %}
+{% if cookiecutter.amazon_web_services.availability_zones is defined %}
   default     = {{ cookiecutter.amazon_web_services.availability_zones | jsonify }}
-  {% else %}
+{% else %}
   default     = []
-  {% endif %}
+{% endif %}
 }
 
 variable "vpc_cidr_block" {

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/variables.tf
@@ -17,7 +17,11 @@ variable "region" {
 variable "availability_zones" {
   description = "AWS availability zones within AWS region"
   type        = list(string)
+  {% if cookiecutter.amazon_web_services.availability_zones is defined %}
   default     = {{ cookiecutter.amazon_web_services.availability_zones | jsonify }}
+  {% else %}
+  default     = []
+  {% endif %}
 }
 
 variable "vpc_cidr_block" {


### PR DESCRIPTION
AWS_DEFAULT_REGION was always set as a GitHub secret when `qhub init` auto-provisions a GitHub repo, but the region was never set in the qhub-config.yaml file. It was always left as a hardcoded us-west-2.

Additionally, availability_zones of us-west-2a and us-west-2b were hardcoded.

This PR:
-  respects AWS_DEFAULT_REGION and inserts that into qhub-config.yaml
- no longer requires availability_zones to be set in qhub-config.yaml
- if qhub-config.yaml does contain availability_zones those will be used

Note that availability_zones is still allowed in qhub-config.yaml:
1. for backwards-compatibility
2. in case the user does have a preference

However, I do not believe it is possible to use `qhub deploy` to migrate an existing qhub to newly-specified availability zones (or regions, for that matter?)

This new approach could therefore cause problems if AWS starts to return different availability zones, or even just in a different order. (Maybe there is a known solution in this situation - I haven't studied it yet.)

If this PR is approved, we need to create similar issues for the other clouds if they have similar data sources available.