### PR TITLE
Actions push command does not filter main branches correctly

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/qhub-ops.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/qhub-ops.yaml
@@ -32,7 +32,7 @@ jobs:
           git config user.name "github action"
           git add .
           # only commit and push if we have changes
-          git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin master)
+          git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin {{ cookiecutter.ci_cd.branch }})
         env:
           COMMIT_MSG: |
             qhub-config.yaml automated commit: {{ '${{ github.sha }}' }}


### PR DESCRIPTION
During a recent deployment of Qhub using the `main` branch as default, the CI job wasn't able to complete the `git push origin master` command. This PR aims to enable the option to choose branches in that command.