### PR TITLE
Terraform errors are caught, and qhub returns exit code 1

### DIFF
--- a/qhub/cli/__init__.py
+++ b/qhub/cli/__init__.py
@@ -42,5 +42,5 @@ def cli(args):
         args.func(args)
     except ValueError as ve:
         sys.exit("\nProblem encountered: " + str(ve) + "\n")
-    except TerraformException as te:
+    except TerraformException:
         sys.exit("\nProblem encountered: Terraform error\n")

--- a/qhub/cli/__init__.py
+++ b/qhub/cli/__init__.py
@@ -40,4 +40,4 @@ def cli(args):
     try:
         args.func(args)
     except ValueError as ve:
-        print("\nProblem encountered:", ve, "\n")
+        sys.exit("\nProblem encountered: "+str(ve)+"\n")

--- a/qhub/cli/__init__.py
+++ b/qhub/cli/__init__.py
@@ -8,6 +8,7 @@ from qhub.cli.initialize import create_init_subcommand
 from qhub.cli.render import create_render_subcommand
 from qhub.cli.validate import create_validate_subcommand
 from qhub.cli.destroy import create_destroy_subcommand
+from qhub.provider.terraform import TerraformException
 
 root_dir = path.abspath(path.join(path.dirname(__file__), path.pardir))
 
@@ -41,3 +42,5 @@ def cli(args):
         args.func(args)
     except ValueError as ve:
         sys.exit("\nProblem encountered: "+str(ve)+"\n")
+    except TerraformException as te:
+        sys.exit("\nProblem encountered: Terraform error\n")

--- a/qhub/cli/__init__.py
+++ b/qhub/cli/__init__.py
@@ -41,6 +41,6 @@ def cli(args):
     try:
         args.func(args)
     except ValueError as ve:
-        sys.exit("\nProblem encountered: "+str(ve)+"\n")
+        sys.exit("\nProblem encountered: " + str(ve) + "\n")
     except TerraformException as te:
         sys.exit("\nProblem encountered: Terraform error\n")

--- a/qhub/cli/initialize.py
+++ b/qhub/cli/initialize.py
@@ -4,7 +4,6 @@ from ruamel import yaml
 
 from qhub.initialize import render_config
 from qhub.schema import ProviderEnum
-from qhub.utils import namestr_regex
 
 
 def create_init_subcommand(subparser):
@@ -65,16 +64,6 @@ def create_init_subcommand(subparser):
 
 
 def handle_init(args):
-
-    if not re.match(namestr_regex, args.project):
-        raise ValueError(
-            "--project name should contain only letters and hyphens/underscores (but not at the start or end)"
-        )
-
-    if not re.match(namestr_regex, args.namespace):
-        raise ValueError(
-            "--namespace should contain only letters and hyphens/underscores (but not at the start or end)"
-        )
 
     config = render_config(
         project_name=args.project,

--- a/qhub/cli/initialize.py
+++ b/qhub/cli/initialize.py
@@ -1,5 +1,3 @@
-import re
-
 from ruamel import yaml
 
 from qhub.initialize import render_config

--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -12,6 +12,7 @@ from qhub.provider.oauth.auth0 import create_client
 from qhub.provider.cicd import github
 from qhub.provider import git
 from qhub.provider.cloud import digital_ocean
+from qhub.utils import namestr_regex
 
 
 BASE_CONFIGURATION = {
@@ -253,8 +254,18 @@ def render_config(
         project_name = input("Provide project name: ")
     config["project_name"] = project_name
 
+    if not re.match(namestr_regex, project_name):
+        raise ValueError(
+            "project name should contain only letters and hyphens/underscores (but not at the start or end)"
+        )
+
     if namespace is not None:
         config["namespace"] = namespace
+
+    if not re.match(namestr_regex, namespace):
+        raise ValueError(
+            "namespace should contain only letters and hyphens/underscores (but not at the start or end)"
+        )
 
     if qhub_domain is None and not disable_prompt:
         qhub_domain = input("Provide domain: ")

--- a/qhub/provider/terraform.py
+++ b/qhub/provider/terraform.py
@@ -15,6 +15,7 @@ from qhub import constants
 
 logger = logging.getLogger(__name__)
 
+
 class TerraformException(Exception):
     pass
 
@@ -59,6 +60,7 @@ def run_terraform_subprocess(processargs, **kwargs):
     if run_subprocess_cmd([terraform_path] + processargs, **kwargs):
         raise TerraformException("Terraform returned an error")
 
+
 def version():
     terraform_path = download_terraform_binary()
     logger.info(f"checking terraform={terraform_path} version")
@@ -78,12 +80,8 @@ def init(directory=None):
 def apply(directory=None, targets=None):
     targets = targets or []
 
-    logger.info(
-        f"terraform= apply directory={directory} targets={targets}"
-    )
-    command = ["apply", "-auto-approve"] + [
-        "-target=" + _ for _ in targets
-    ]
+    logger.info(f"terraform= apply directory={directory} targets={targets}")
+    command = ["apply", "-auto-approve"] + ["-target=" + _ for _ in targets]
     with timer(logger, "terraform apply"):
         run_terraform_subprocess(command, cwd=directory, prefix="terraform")
 

--- a/qhub/utils.py
+++ b/qhub/utils.py
@@ -36,12 +36,14 @@ def run_subprocess_cmd(processargs, **kwargs):
         kwargs.pop("prefix")
     else:
         line_prefix = b""
-    
+
     process = subprocess.Popen(processargs, **kwargs, stdout=subprocess.PIPE)
     for line in iter(lambda: process.stdout.readline(), b""):
         sys.stdout.buffer.write(line_prefix + line)
         sys.stdout.flush()
-    return process.wait(timeout=10) # Should already have finished because we have drained stdout
+    return process.wait(
+        timeout=10
+    )  # Should already have finished because we have drained stdout
 
 
 def check_cloud_credentials(config):

--- a/qhub/utils.py
+++ b/qhub/utils.py
@@ -29,18 +29,19 @@ def change_directory(directory):
     os.chdir(current_directory)
 
 
-def run_subprocess_cmd(*args, **kwargs):
+def run_subprocess_cmd(processargs, **kwargs):
     """Runs subprocess command with realtime stdout logging with optional line prefix."""
     if "prefix" in kwargs:
         line_prefix = f"[{kwargs['prefix']}]: ".encode("utf-8")
         kwargs.pop("prefix")
     else:
         line_prefix = b""
-
-    process = subprocess.Popen(*args, **kwargs, stdout=subprocess.PIPE)
+    
+    process = subprocess.Popen(processargs, **kwargs, stdout=subprocess.PIPE)
     for line in iter(lambda: process.stdout.readline(), b""):
         sys.stdout.buffer.write(line_prefix + line)
         sys.stdout.flush()
+    return process.wait(timeout=10) # Should already have finished because we have drained stdout
 
 
 def check_cloud_credentials(config):


### PR DESCRIPTION
Previously, terraform errors were silent and did not propagate into qhub cli.

Now they are raised (for init, apply, destroy) and qhub returns exit code 1, so GitHub actions know it failed.

Also return exit code 1 for other validation errors etc, and check project/namespace regex in a better place to allow for manually input values where not passed on the command line.