### PR TITLE
Create shared/.userskel folder to be copied to users' home

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ gcp-jupyterhub
 modules
 quansight-terraform-modules
 config.yaml
-data
+data*
 
 # ignore qhub files
 qhub-config.yaml

--- a/qhub/template/{{ cookiecutter.repo_directory }}/templates/jupyterhub_config.py.j2
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/templates/jupyterhub_config.py.j2
@@ -105,7 +105,8 @@ def qhub_configure_profile(username, safe_username, profile):
                 "command": ["/bin/sh", "-c", (
                      "echo '{passwd}' > /tmp/passwd && "
                      "echo '{group}' > /tmp/group && "
-                     "ln -sfn /home/shared /home/jovyan/shared"
+                     "ln -sfn /home/shared /home/jovyan/shared && "
+                     "cp -nrT /home/shared/.userskel /home/jovyan"
                 ).format(passwd=passwd, group=group)]
             }
         }
@@ -115,13 +116,19 @@ def qhub_configure_profile(username, safe_username, profile):
         {
              "name": "init-nfs",
              "image": "busybox:1.31",
-             "command": ["sh", "-c", ' && '.join([
-                  "mkdir -p /mnt/home/{username}",
-                  "chmod 700 /mnt/home/{username}",
-                  "chown {uid}:{primary_gid} /mnt/home/{username}",
-                  "mkdir -p /mnt/home/shared",
-                  "chmod 777 /mnt/home/shared"
-             ] + ["mkdir -p /mnt/home/shared/{groupname} && chmod 2770 /mnt/home/shared/{groupname} && chown 0:{gid} /mnt/home/shared/{groupname}".format(groupname=groupname, gid=config['gid']) for groupname, config in QHUB_GROUP_MAPPING.items()]).format(username=safe_username, uid=uid, primary_gid=primary_gid)],
+             "command": ["sh", "-c", ' && '.join(
+                    [
+                    "mkdir -p /mnt/home/{username}",
+                    "chmod 700 /mnt/home/{username}",
+                    "chown {uid}:{primary_gid} /mnt/home/{username}",
+                    "mkdir -p /mnt/home/shared",
+                    "chmod 777 /mnt/home/shared"
+                    ] 
+                    + ["mkdir -p /mnt/home/shared/{groupname} && chmod 2770 /mnt/home/shared/{groupname} && chown 0:{gid} /mnt/home/shared/{groupname}".format(groupname=groupname, gid=config['gid']) for groupname, config in QHUB_GROUP_MAPPING.items()]
+                    + ["mkdir -p /mnt/home/shared/.userskel && chmod 2775 /mnt/home/shared/.userskel && chown 0:{gid} /mnt/home/shared/.userskel".format(gid=QHUB_GROUP_MAPPING.get('admin', {'gid':0})['gid'])]
+                ).format(username=safe_username, uid=uid, primary_gid=primary_gid)
+             ]
+             ,
              "securityContext": {"runAsUser": 0},
              "volumeMounts": [{"mountPath": "/mnt", "name": "home"}]
         }


### PR DESCRIPTION
There will be a new shared/.userskel folder ('user skeleton').

The contents of this will be copied to any user's home folder on spawn of a server (but not overwriting any existing files).

.userskel is admin-writable but only readable by other users.

This PR is a solution, at least for the inspiration behind, #391
