### PR TITLE
Improvements to qhub destroy and terraform-state sync

### DIFF
--- a/qhub/cli/destroy.py
+++ b/qhub/cli/destroy.py
@@ -5,6 +5,7 @@ from ruamel import yaml
 
 from qhub.destroy import destroy_configuration
 from qhub.schema import verify
+from qhub.render import render_default_template, render_template
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +13,13 @@ logger = logging.getLogger(__name__)
 def create_destroy_subcommand(subparser):
     subparser = subparser.add_parser("destroy")
     subparser.add_argument("-c", "--config", help="qhub configuration", required=True)
+    subparser.add_argument("-i", "--input", help="input directory")
+    subparser.add_argument("-o", "--output", default="./", help="output directory")
+    subparser.add_argument(
+        "--disable-render",
+        action="store_true",
+        help="Disable auto-rendering before destroy",
+    )
     subparser.set_defaults(func=handle_destroy)
 
 
@@ -26,5 +34,11 @@ def handle_destroy(args):
         config = yaml.safe_load(f.read())
 
     verify(config)
+
+    if not args.disable_render:
+        if args.input is None:
+            render_default_template(args.output, args.config, force=True)
+        else:
+            render_template(args.input, args.output, args.config, force=True)
 
     destroy_configuration(config)

--- a/qhub/cli/destroy.py
+++ b/qhub/cli/destroy.py
@@ -16,6 +16,11 @@ def create_destroy_subcommand(subparser):
     subparser.add_argument("-i", "--input", help="input directory")
     subparser.add_argument("-o", "--output", default="./", help="output directory")
     subparser.add_argument(
+        "--skip-remote-state-provision",
+        action="store_true",
+        help="Skip terraform state import and destroy",
+    )
+    subparser.add_argument(
         "--disable-render",
         action="store_true",
         help="Disable auto-rendering before destroy",
@@ -41,4 +46,7 @@ def handle_destroy(args):
         else:
             render_template(args.input, args.output, args.config, force=True)
 
-    destroy_configuration(config)
+    destroy_configuration(
+        config,
+        args.skip_remote_state_provision,
+    )

--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -2,9 +2,10 @@ import logging
 import re
 from subprocess import CalledProcessError
 
-from qhub.provider import terraform
-from qhub.utils import timer, check_cloud_credentials
-from qhub.provider.dns.cloudflare import update_record
+from .provider import terraform
+from .utils import timer, check_cloud_credentials
+from .provider.dns.cloudflare import update_record
+from .state import terraform_state_sync
 
 logger = logging.getLogger(__name__)
 
@@ -50,8 +51,7 @@ def guided_install(
         and (config.get("terraform_state", {}).get("type") == "remote")
         and (config.get("provider") != "local")
     ):
-        terraform.init(directory="terraform-state")
-        terraform.apply(directory="terraform-state")
+        terraform_state_sync(config)
 
     # 3 kuberentes-alpha provider requires that kubernetes be
     # provisionioned before any "kubernetes_manifests" resources

--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -3,11 +3,7 @@ import re
 from subprocess import CalledProcessError
 
 from qhub.provider import terraform
-from qhub.utils import (
-    timer,
-    check_cloud_credentials,
-    verify_configuration_file_exists,
-)
+from qhub.utils import timer, check_cloud_credentials
 from qhub.provider.dns.cloudflare import update_record
 
 logger = logging.getLogger(__name__)
@@ -43,13 +39,10 @@ def guided_install(
     disable_prompt=False,
     skip_remote_state_provision=False,
 ):
-    # 01 Verify configuration file exists
-    verify_configuration_file_exists()
-
-    # 02 Check Environment Variables
+    # 01 Check Environment Variables
     check_cloud_credentials(config)
 
-    # 03 Create terraform backend remote state bucket
+    # 02 Create terraform backend remote state bucket
     # backwards compatible with `qhub-config.yaml` which
     # don't have `terraform_state` key
     if (
@@ -60,7 +53,7 @@ def guided_install(
         terraform.init(directory="terraform-state")
         terraform.apply(directory="terraform-state")
 
-    # 3.5 kuberentes-alpha provider requires that kubernetes be
+    # 3 kuberentes-alpha provider requires that kubernetes be
     # provisionioned before any "kubernetes_manifests" resources
     terraform.init(directory="infrastructure")
     terraform.apply(

--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -2,10 +2,10 @@ import logging
 import re
 from subprocess import CalledProcessError
 
-from .provider import terraform
-from .utils import timer, check_cloud_credentials
-from .provider.dns.cloudflare import update_record
-from .state import terraform_state_sync
+from qhub.provider import terraform
+from qhub.utils import timer, check_cloud_credentials
+from qhub.provider.dns.cloudflare import update_record
+from qhub.state import terraform_state_sync
 
 logger = logging.getLogger(__name__)
 

--- a/qhub/destroy.py
+++ b/qhub/destroy.py
@@ -1,8 +1,8 @@
 import logging
 
-from .utils import timer, check_cloud_credentials
-from .provider import terraform
-from .state import terraform_state_sync
+from qhub.utils import timer, check_cloud_credentials
+from qhub.provider import terraform
+from qhub.state import terraform_state_sync
 
 logger = logging.getLogger(__name__)
 

--- a/qhub/destroy.py
+++ b/qhub/destroy.py
@@ -7,7 +7,7 @@ from .state import terraform_state_sync
 logger = logging.getLogger(__name__)
 
 
-def destroy_configuration(config):
+def destroy_configuration(config, skip_remote_state_provision=False):
     logger.info(
         """Removing all infrastructure, your local files will still remain, \n
     you can use 'qhub deploy' to re - install infrastructure using same config file"""
@@ -24,8 +24,10 @@ def destroy_configuration(config):
         # 03 Remove terraform backend remote state bucket
         # backwards compatible with `qhub-config.yaml` which
         # don't have `terraform_state` key
-        if (config.get("terraform_state", {}).get("type") == "remote") and (
-            config.get("provider") != "local"
+        if (
+            (not skip_remote_state_provision)
+            and (config.get("terraform_state", {}).get("type") == "remote")
+            and (config.get("provider") != "local")
         ):
             terraform_state_sync(config)
             terraform.destroy(directory="terraform-state")

--- a/qhub/destroy.py
+++ b/qhub/destroy.py
@@ -1,8 +1,8 @@
 import logging
 
-from qhub.utils import timer, check_cloud_credentials
-from qhub.provider import terraform
-
+from .utils import timer, check_cloud_credentials
+from .provider import terraform
+from .state import terraform_state_sync
 
 logger = logging.getLogger(__name__)
 
@@ -27,55 +27,5 @@ def destroy_configuration(config):
         if (config.get("terraform_state", {}).get("type") == "remote") and (
             config.get("provider") != "local"
         ):
-            terraform.init(directory="terraform-state")
-
-            provider = config.get("provider")
-            project_name = config.get("project_name")
-            namespace = config.get("namespace")
-
-            terraform.rm_local_state(directory="terraform-state")
-
-            # TODO First need to do, e.g.:
-
-            # AWS
-            # terraform import module.terraform-state.aws_s3_bucket.terraform-state qhubintgrtnaws-dev-terraform-state
-            # terraform import module.terraform-state.aws_dynamodb_table.terraform-state-lock qhubintgrtnaws-dev-terraform-state-lock
-
-            # GCP
-            # terraform import module.terraform-state.module.gcs.google_storage_bucket.static-site qhubintgrtngcp-dev-terraform-state
-            # But needs terraform apply to import force_destroy: https://github.com/hashicorp/terraform-provider-google/issues/1509
-
-            if provider == "aws":
-                terraform.tfimport(
-                    "module.terraform-state.aws_s3_bucket.terraform-state",
-                    f"{project_name}-{namespace}-terraform-state",
-                    directory="terraform-state",
-                )
-                terraform.tfimport(
-                    "module.terraform-state.aws_dynamodb_table.terraform-state-lock",
-                    f"{project_name}-{namespace}-terraform-state-lock",
-                    directory="terraform-state",
-                )
-
-            elif provider == "gcp":
-                terraform.tfimport(
-                    "module.terraform-state.module.gcs.google_storage_bucket.static-site",
-                    f"{project_name}-{namespace}-terraform-state",
-                    directory="terraform-state",
-                )
-
-            elif provider == "do":
-                terraform.tfimport(
-                    "module.terraform-state.module.spaces.digitalocean_spaces_bucket.main",
-                    f"{project_name}-{namespace}-terraform-state",
-                    directory="terraform-state",
-                )
-
-            elif provider == "azure":
-                raise Exception("Need to import azure terraform-state")
-
-            terraform.apply(
-                directory="terraform-state"
-            )  # Mainly to sync force_destroy attribute to buckets
-
+            terraform_state_sync(config)
             terraform.destroy(directory="terraform-state")

--- a/qhub/destroy.py
+++ b/qhub/destroy.py
@@ -1,10 +1,6 @@
 import logging
 
-from qhub.utils import (
-    timer,
-    check_cloud_credentials,
-    verify_configuration_file_exists,
-)
+from qhub.utils import timer, check_cloud_credentials
 from qhub.provider import terraform
 
 
@@ -18,21 +14,68 @@ def destroy_configuration(config):
     )
 
     with timer(logger, "destroying QHub"):
-        # 01 Verify configuration file exists
-        verify_configuration_file_exists()
-
-        # 02 Check Environment Variables
+        # 01 Check Environment Variables
         check_cloud_credentials(config)
 
-        # 03 Remove all infrastructure
+        # 02 Remove all infrastructure
         terraform.init(directory="infrastructure")
         terraform.destroy(directory="infrastructure")
 
-        # 06 Remove terraform backend remote state bucket
+        # 03 Remove terraform backend remote state bucket
         # backwards compatible with `qhub-config.yaml` which
         # don't have `terraform_state` key
         if (config.get("terraform_state", {}).get("type") == "remote") and (
             config.get("provider") != "local"
         ):
             terraform.init(directory="terraform-state")
+
+            provider = config.get("provider")
+            project_name = config.get("project_name")
+            namespace = config.get("namespace")
+
+            terraform.rm_local_state(directory="terraform-state")
+
+            # TODO First need to do, e.g.:
+
+            # AWS
+            # terraform import module.terraform-state.aws_s3_bucket.terraform-state qhubintgrtnaws-dev-terraform-state
+            # terraform import module.terraform-state.aws_dynamodb_table.terraform-state-lock qhubintgrtnaws-dev-terraform-state-lock
+
+            # GCP
+            # terraform import module.terraform-state.module.gcs.google_storage_bucket.static-site qhubintgrtngcp-dev-terraform-state
+            # But needs terraform apply to import force_destroy: https://github.com/hashicorp/terraform-provider-google/issues/1509
+
+            if provider == "aws":
+                terraform.tfimport(
+                    "module.terraform-state.aws_s3_bucket.terraform-state",
+                    f"{project_name}-{namespace}-terraform-state",
+                    directory="terraform-state",
+                )
+                terraform.tfimport(
+                    "module.terraform-state.aws_dynamodb_table.terraform-state-lock",
+                    f"{project_name}-{namespace}-terraform-state-lock",
+                    directory="terraform-state",
+                )
+
+            elif provider == "gcp":
+                terraform.tfimport(
+                    "module.terraform-state.module.gcs.google_storage_bucket.static-site",
+                    f"{project_name}-{namespace}-terraform-state",
+                    directory="terraform-state",
+                )
+
+            elif provider == "do":
+                terraform.tfimport(
+                    "module.terraform-state.module.spaces.digitalocean_spaces_bucket.main",
+                    f"{project_name}-{namespace}-terraform-state",
+                    directory="terraform-state",
+                )
+
+            elif provider == "azure":
+                raise Exception("Need to import azure terraform-state")
+
+            terraform.apply(
+                directory="terraform-state"
+            )  # Mainly to sync force_destroy attribute to buckets
+
             terraform.destroy(directory="terraform-state")

--- a/qhub/provider/terraform.py
+++ b/qhub/provider/terraform.py
@@ -100,7 +100,9 @@ def tfimport(addr, id, directory=None):
     logger.info(f"terraform import directory={directory} addr={addr} id={id}")
     command = ["import", addr, id]
     with timer(logger, "terraform import"):
-        run_terraform_subprocess(command, cwd=directory, prefix="terraform")
+        run_terraform_subprocess(
+            command, cwd=directory, prefix="terraform", strip_errors=True
+        )
 
 
 def destroy(directory=None):

--- a/qhub/provider/terraform.py
+++ b/qhub/provider/terraform.py
@@ -80,7 +80,7 @@ def init(directory=None):
 def apply(directory=None, targets=None):
     targets = targets or []
 
-    logger.info(f"terraform= apply directory={directory} targets={targets}")
+    logger.info(f"terraform apply directory={directory} targets={targets}")
     command = ["apply", "-auto-approve"] + ["-target=" + _ for _ in targets]
     with timer(logger, "terraform apply"):
         run_terraform_subprocess(command, cwd=directory, prefix="terraform")
@@ -96,8 +96,15 @@ def output(directory=None):
         ).decode("utf8")[:-1]
 
 
+def tfimport(addr, id, directory=None):
+    logger.info(f"terraform import directory={directory} addr={addr} id={id}")
+    command = ["import", addr, id]
+    with timer(logger, "terraform import"):
+        run_terraform_subprocess(command, cwd=directory, prefix="terraform")
+
+
 def destroy(directory=None):
-    logger.info(f"terraform= destroy directory={directory}")
+    logger.info(f"terraform destroy directory={directory}")
     command = [
         "destroy",
         "-auto-approve",
@@ -105,3 +112,13 @@ def destroy(directory=None):
 
     with timer(logger, "terraform destroy"):
         run_terraform_subprocess(command, cwd=directory, prefix="terraform")
+
+
+def rm_local_state(directory=None):
+    logger.info(f"rm local state file terraform.tfstate directory={directory}")
+    tfstate_path = "terraform.tfstate"
+    if directory:
+        tfstate_path = os.path.join(directory, tfstate_path)
+
+    if os.path.isfile(tfstate_path):
+        os.remove(tfstate_path)

--- a/qhub/state.py
+++ b/qhub/state.py
@@ -1,0 +1,68 @@
+from .provider import terraform
+
+
+def terraform_state_sync(config, logger=None):
+    """
+    Clear terraform-state terraform.tfstate and re-import from cloud (if exists)
+    then terraform apply to ensure state is correct in cloud too
+    """
+    terraform.init(directory="terraform-state")
+
+    provider = config.get("provider")
+    project_name = config.get("project_name")
+    namespace = config.get("namespace")
+
+    terraform.rm_local_state(directory="terraform-state")
+
+    # Example imports:
+
+    # AWS
+    # terraform import module.terraform-state.aws_s3_bucket.terraform-state qhubintgrtnaws-dev-terraform-state
+    # terraform import module.terraform-state.aws_dynamodb_table.terraform-state-lock qhubintgrtnaws-dev-terraform-state-lock
+
+    # GCP
+    # terraform import module.terraform-state.module.gcs.google_storage_bucket.static-site qhubintgrtngcp-dev-terraform-state
+    # But needs terraform apply to import force_destroy: https://github.com/hashicorp/terraform-provider-google/issues/1509
+
+    try:
+        if provider == "aws":
+            terraform.tfimport(
+                "module.terraform-state.aws_s3_bucket.terraform-state",
+                f"{project_name}-{namespace}-terraform-state",
+                directory="terraform-state",
+            )
+            terraform.tfimport(
+                "module.terraform-state.aws_dynamodb_table.terraform-state-lock",
+                f"{project_name}-{namespace}-terraform-state-lock",
+                directory="terraform-state",
+            )
+
+        elif provider == "gcp":
+            terraform.tfimport(
+                "module.terraform-state.module.gcs.google_storage_bucket.static-site",
+                f"{project_name}-{namespace}-terraform-state",
+                directory="terraform-state",
+            )
+
+        elif provider == "do":
+            do_region = config.get("digital_ocean", {}).get("region", "nyc3")
+
+            terraform.tfimport(
+                "module.terraform-state.module.spaces.digitalocean_spaces_bucket.main",
+                f"{do_region},{project_name}-{namespace}-terraform-state",
+                directory="terraform-state",
+            )
+
+        elif provider == "azure":
+            raise Exception("Need to import azure terraform-state")
+
+    except terraform.TerraformException:
+        if logger:
+            logger.info(
+                "Terraform error presumed to be due to importing a resource which does not exist yet"
+            )
+
+    terraform.apply(
+        directory="terraform-state"
+    )  # If before destroy, this is mainly to sync force_destroy attribute to buckets
+    # If before deploy, this may be to create the resources for the first time

--- a/qhub/state.py
+++ b/qhub/state.py
@@ -1,5 +1,6 @@
 import os
-from .provider import terraform
+
+from qhub.provider import terraform
 
 
 def terraform_state_sync(config, logger=None):

--- a/qhub/utils.py
+++ b/qhub/utils.py
@@ -109,8 +109,3 @@ def check_cloud_credentials(config):
         pass
     else:
         raise Exception("Cloud Provider configuration not supported")
-
-
-def verify_configuration_file_exists():
-    if not path.exists("qhub-config.yaml"):
-        raise Exception('Configuration file "qhub-config.yaml" does not exist')

--- a/qhub/utils.py
+++ b/qhub/utils.py
@@ -4,7 +4,6 @@ import time
 import os
 import re
 import contextlib
-from os import path
 
 DO_ENV_DOCS = "https://github.com/Quansight/qhub/blob/master/docs/docs/do/installation.md#environment-variables"
 AWS_ENV_DOCS = "https://github.com/Quansight/qhub/blob/master/docs/docs/aws/installation.md#environment-variables"


### PR DESCRIPTION
To improve `qhub destroy`:

- Render terraform files before destroy (like deploy) by default
- Assume terraform-state/terraform.tfstate is old or not present (for remote backends)
- Import state from cloud

This is especially useful for integration tests because the state buckets are not currently being destroyed, making it difficult to start the test next time round.

AWS/GCP now working. Attempt at Digital Ocean import but fails with:
```
[terraform]: module.terraform-state.module.spaces.digitalocean_spaces_bucket.main: Importing from ID "qhubintgrtndo-dev-terraform-state"...
[terraform]: module.terraform-state.module.spaces.digitalocean_spaces_bucket.main: Import prepared!
[terraform]:   Prepared digitalocean_spaces_bucket for import
[terraform]: module.terraform-state.module.spaces.digitalocean_spaces_bucket.main: Refreshing state... [id=qhubintgrtndo-dev-terraform-state]

Error: error reading Spaces bucket "qhubintgrtndo-dev-terraform-state": RequestError: send request failed
caused by: Head "https://qhubintgrtndo-dev-terraform-state..digitaloceanspaces.com/": dial tcp: lookup qhubintgrtndo-dev-terraform-state..digitaloceanspaces.com: no such host
```

This looks as though the region (e.g. nyc3) is not being inserted into the URL.

Azure  - no attempt yet
