### PR TITLE
spawn_default_options False to force dashboard owner to pick profile

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/templates/jupyterhub_config.py.j2
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/templates/jupyterhub_config.py.j2
@@ -12,6 +12,9 @@ c.VariableMixin.default_presentation_cmd = ['python3', '-m', 'jhsingle_native_pr
 
 c.JupyterHub.default_url = '/hub/home'
 
+# Force dashboard creator to select an instance size
+c.CDSDashboardsConfig.spawn_default_options = False
+
 {% else %}
 
 c.JupyterHub.allow_named_servers = False


### PR DESCRIPTION
This PR adds a setting to jupyterhub_config which ensures the dashboard owner has to pick a server profile when they first launch a dashboard.

The downside is that if they stop their server, only they can restart it.

The upside is that they:

1. Can choose which profile they want...
2. Showing the form sets the initContainers correctly so permissions are set