### PR TITLE
Adding command line argument to skip provisioning remote-state on deployment

### DIFF
--- a/qhub/cli/deploy.py
+++ b/qhub/cli/deploy.py
@@ -21,6 +21,11 @@ def create_deploy_subcommand(subparser):
         help="dns provider to use for registering domain name mapping",
     )
     subparser.add_argument(
+        "--skip-remote-state-provision",
+        action="store_true",
+        help="Skip terraform state deployment which is often required in CI once the terraform remote state bootstrapping phase is complete",
+    )
+    subparser.add_argument(
         "--dns-auto-provision",
         action="store_true",
         help="Attempt to automatically provision DNS. For Auth0 is requires environment variables AUTH0_DOMAIN, AUTH0_CLIENTID, AUTH0_CLIENT_SECRET",
@@ -57,5 +62,9 @@ def handle_deploy(args):
             render_template(args.input, args.output, args.config, force=True)
 
     deploy_configuration(
-        config, args.dns_provider, args.dns_auto_provision, args.disable_prompt
+        config,
+        args.dns_provider,
+        args.dns_auto_provision,
+        args.disable_prompt,
+        args.skip_remote_state_provision,
     )

--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -13,18 +13,36 @@ from qhub.provider.dns.cloudflare import update_record
 logger = logging.getLogger(__name__)
 
 
-def deploy_configuration(config, dns_provider, dns_auto_provision, disable_prompt):
+def deploy_configuration(
+    config,
+    dns_provider,
+    dns_auto_provision,
+    disable_prompt,
+    skip_remote_state_provision,
+):
     logger.info(f'All qhub endpoints will be under https://{config["domain"]}')
 
     with timer(logger, "deploying QHub"):
         try:
-            guided_install(config, dns_provider, dns_auto_provision, disable_prompt)
+            guided_install(
+                config,
+                dns_provider,
+                dns_auto_provision,
+                disable_prompt,
+                skip_remote_state_provision,
+            )
         except CalledProcessError as e:
             logger.error(e.output)
             raise e
 
 
-def guided_install(config, dns_provider, dns_auto_provision, disable_prompt=False):
+def guided_install(
+    config,
+    dns_provider,
+    dns_auto_provision,
+    disable_prompt=False,
+    skip_remote_state_provision=False,
+):
     # 01 Verify configuration file exists
     verify_configuration_file_exists()
 
@@ -34,8 +52,10 @@ def guided_install(config, dns_provider, dns_auto_provision, disable_prompt=Fals
     # 03 Create terraform backend remote state bucket
     # backwards compatible with `qhub-config.yaml` which
     # don't have `terraform_state` key
-    if (config.get("terraform_state", {}).get("type") == "remote") and (
-        config.get("provider") != "local"
+    if (
+        (not skip_remote_state_provision)
+        and (config.get("terraform_state", {}).get("type") == "remote")
+        and (config.get("provider") != "local")
     ):
         terraform.init(directory="terraform-state")
         terraform.apply(directory="terraform-state")

--- a/qhub/template/{{ cookiecutter.repo_directory }}/.gitlab-ci.yml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/.gitlab-ci.yml
@@ -13,7 +13,7 @@ render-qhub:
 {%- endif %}
   script:
     - pip install qhub==0.3.4
-    - qhub deploy --config qhub-config.yaml --disable-prompt
+    - qhub deploy --config qhub-config.yaml --disable-prompt --skip-remote-state-provision
     - git config user.email "qhub@quansight.com"
     - git config user.name "gitlab ci"
     - git add .


### PR DESCRIPTION
When doing infrastructure as code update via github-actions and gitlab-ci the remote state has already been provisioned. We need a way within CI to tell `qhub deploy` to not actually run the `terraform apply` within the `terraform-state` directory since the remote state is already created.