### PR TITLE
Set conda_envs for dashboards

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/templates/jupyterhub_config.py.j2
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/templates/jupyterhub_config.py.j2
@@ -15,6 +15,12 @@ c.JupyterHub.default_url = '/hub/home'
 # Force dashboard creator to select an instance size
 c.CDSDashboardsConfig.spawn_default_options = False
 
+c.CDSDashboardsConfig.conda_envs = [
+{%- for key in cookiecutter.environments %}
+    "{{ cookiecutter.environments[key].name }}", 
+{%- endfor %}
+]
+
 {% else %}
 
 c.JupyterHub.allow_named_servers = False


### PR DESCRIPTION
Sets c.CDSDashboardsConfig.conda_envs in jupyterhub_config so that the user can choose the Conda Env when creating/editing the dashboard.

Closes #530 