### PR TITLE
Pydantic correct validation, github auto-provision checks

### DIFF
--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -48,7 +48,7 @@ def guided_install(
     # don't have `terraform_state` key
     if (
         (not skip_remote_state_provision)
-        and (config.get("terraform_state", {}).get("type") == "remote")
+        and (config.get("terraform_state", {}).get("type", "") == "remote")
         and (config.get("provider") != "local")
     ):
         terraform_state_sync(config)

--- a/qhub/destroy.py
+++ b/qhub/destroy.py
@@ -26,7 +26,7 @@ def destroy_configuration(config, skip_remote_state_provision=False):
         # don't have `terraform_state` key
         if (
             (not skip_remote_state_provision)
-            and (config.get("terraform_state", {}).get("type") == "remote")
+            and (config.get("terraform_state", {}).get("type", "") == "remote")
             and (config.get("provider") != "local")
         ):
             terraform_state_sync(config)

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -49,8 +49,8 @@ class Base(pydantic.BaseModel):
 
 
 class CICD(Base):
-    type: CiEnum = "github-actions"
-    branch: str = "main"
+    type: CiEnum
+    branch: str
     before_script: typing.Optional[typing.List[str]]
     after_script: typing.Optional[typing.List[str]]
 
@@ -59,14 +59,14 @@ class CICD(Base):
 
 
 class TerraformState(Base):
-    type: TerraformStateEnum = "remote"
+    type: TerraformStateEnum
     backend: typing.Optional[str]
     config: typing.Optional[typing.Dict[str, str]]
 
 
 class TerraformModules(Base):
-    repository: str = "github.com/quansight/qhub-terraform-modules"
-    rev: str = "main"
+    repository: str
+    rev: str
 
 
 # ============ Certificate =============
@@ -154,9 +154,9 @@ class NodeSelector(Base):
 
 
 class NodeGroup(Base):
-    instance: str = "s-2vcpu-4gb"
-    min_nodes: int = 1
-    max_nodes: int = 1
+    instance: str
+    min_nodes: int
+    max_nodes: int
 
     class Config:
         extra = "allow"

--- a/qhub/utils.py
+++ b/qhub/utils.py
@@ -7,10 +7,12 @@ import contextlib
 
 from .version import __version__
 
-DO_ENV_DOCS = "https://github.com/Quansight/qhub/blob/master/docs/docs/do/installation.md#environment-variables"
-AWS_ENV_DOCS = "https://github.com/Quansight/qhub/blob/master/docs/docs/aws/installation.md#environment-variables"
-GCP_ENV_DOCS = "https://github.com/Quansight/qhub/blob/master/docs/docs/gcp/installation.md#environment-variables"
-AZURE_ENV_DOCS = "Coming Soon"
+DO_ENV_DOCS = (
+    "https://docs.qhub.dev/en/latest/source/02_get_started/02_setup.html#digital-ocean"
+)
+AWS_ENV_DOCS = "https://docs.qhub.dev/en/latest/source/02_get_started/02_setup.html#amazon-web-services-aws"
+GCP_ENV_DOCS = "https://docs.qhub.dev/en/latest/source/02_get_started/02_setup.html#google-cloud-platform"
+AZURE_ENV_DOCS = "https://docs.qhub.dev/en/latest/source/02_get_started/02_setup.html#microsoft-azure"
 
 qhub_image_tag = f"v{__version__}"
 pip_install_qhub = f"pip install qhub=={__version__}"
@@ -75,7 +77,7 @@ def check_cloud_credentials(config):
     if config["provider"] == "gcp":
         for variable in {"GOOGLE_CREDENTIALS"}:
             if variable not in os.environ:
-                raise Exception(
+                raise ValueError(
                     f"""Missing the following required environment variable: {variable}\n
                     Please see the documentation for more information: {GCP_ENV_DOCS}"""
                 )
@@ -87,7 +89,7 @@ def check_cloud_credentials(config):
             "ARM_TENANT_ID",
         }:
             if variable not in os.environ:
-                raise Exception(
+                raise ValueError(
                     f"""Missing the following required environment variable: {variable}\n
                     Please see the documentation for more information: {AZURE_ENV_DOCS}"""
                 )
@@ -98,7 +100,7 @@ def check_cloud_credentials(config):
             "AWS_DEFAULT_REGION",
         }:
             if variable not in os.environ:
-                raise Exception(
+                raise ValueError(
                     f"""Missing the following required environment variable: {variable}\n
                     Please see the documentation for more information: {AWS_ENV_DOCS}"""
                 )
@@ -111,13 +113,13 @@ def check_cloud_credentials(config):
             "DIGITALOCEAN_TOKEN",
         }:
             if variable not in os.environ:
-                raise Exception(
+                raise ValueError(
                     f"""Missing the following required environment variable: {variable}\n
                     Please see the documentation for more information: {DO_ENV_DOCS}"""
                 )
 
         if os.environ["AWS_ACCESS_KEY_ID"] != os.environ["SPACES_ACCESS_KEY_ID"]:
-            raise Exception(
+            raise ValueError(
                 f"""The environment variables AWS_ACCESS_KEY_ID and SPACES_ACCESS_KEY_ID must be equal\n
                 See {DO_ENV_DOCS} for more information"""
             )
@@ -126,11 +128,11 @@ def check_cloud_credentials(config):
             os.environ["AWS_SECRET_ACCESS_KEY"]
             != os.environ["SPACES_SECRET_ACCESS_KEY"]
         ):
-            raise Exception(
+            raise ValueError(
                 f"""The environment variables AWS_SECRET_ACCESS_KEY and SPACES_SECRET_ACCESS_KEY must be equal\n
                 See {DO_ENV_DOCS} for more information"""
             )
     elif config["provider"] == "local":
         pass
     else:
-        raise Exception("Cloud Provider configuration not supported")
+        raise ValueError("Cloud Provider configuration not supported")


### PR DESCRIPTION
Removed defaults from pydantic schema since they were causing missing values to remain missing, and the defaults were never used anyway - so confusing for developers to see them there. Defaults aren't used because Pydantic is being used for validation but not model initialization.
Closes #539 

GitHub auto-provision - returns errors if provision fails or secrets missing, warns if repo already exists.
Closes #557 
