### PR TITLE
Qhub linter

### DIFF
--- a/qhub/cli/validate.py
+++ b/qhub/cli/validate.py
@@ -3,11 +3,15 @@ import pathlib
 from ruamel import yaml
 
 from qhub.schema import verify
+from qhub.provider.cicd.linter import comment_on_pr
 
 
 def create_validate_subcommand(subparser):
     subparser = subparser.add_parser("validate")
     subparser.add_argument("config", help="qhub configuration")
+    subparser.add_argument(
+        "--enable-commenting", help="Turn on PR commenting", action="store_true"
+    )
     subparser.set_defaults(func=handle_validate)
 
 
@@ -21,4 +25,8 @@ def handle_validate(args):
     with config_filename.open() as f:
         config = yaml.safe_load(f.read())
 
-    verify(config)
+    if args.enable_commenting:
+        # for PR's only
+        comment_on_pr(config)
+    else:
+        verify(config)

--- a/qhub/provider/cicd/linter.py
+++ b/qhub/provider/cicd/linter.py
@@ -18,14 +18,14 @@ def qhub_validate(config):
         verify(config)
         msg = "validate: info: successfully validated QHub configuration"
         print(msg)
-        return True, msg, 1
+        return True, msg, 0
 
     except BaseException as e:
         msg = "validate: error: failed to validate QHub configuration."
         print(msg)
         validate_comment = parse_validation(e)
         validate_comment_wrapper = f" ```{validate_comment}``` "
-        return False, validate_comment_wrapper, 0
+        return False, validate_comment_wrapper, 1
 
 
 def generate_lint_message(config):

--- a/qhub/provider/cicd/linter.py
+++ b/qhub/provider/cicd/linter.py
@@ -37,7 +37,7 @@ def generate_lint_message(config):
 
     pass_lint = textwrap.dedent(
         """
-            This is an automatic response from the QHub-cloud linter.
+            This is an automatic response from the QHub linter.
             I just wanted to let you know that I linted your `qhub-config.yaml` in your PR and I didn't find any
             problems.
             """
@@ -47,7 +47,7 @@ def generate_lint_message(config):
     bad_lint = (
         textwrap.dedent(
             """
-            This is an automatic response from the QHub-cloud linter.
+            This is an automatic response from the QHub linter.
             I just wanted to let you know that I linted your `qhub-config.yaml` in your PR and found some errors:\n"""
         )
         + f"{messages}"
@@ -57,7 +57,7 @@ def generate_lint_message(config):
         status = "no configuration file"
         message = textwrap.dedent(
             """
-            This is an automatic response from the QHub-cloud linter.
+            This is an automatic response from the QHub linter.
             I was trying to look for the `qhub-config.yaml` file to lint for you, but couldn't find any...
             """
         )

--- a/qhub/provider/cicd/linter.py
+++ b/qhub/provider/cicd/linter.py
@@ -24,7 +24,7 @@ def qhub_validate(config):
         msg = "validate: error: failed to validate QHub configuration."
         print(msg)
         validate_comment = parse_validation(e)
-        validate_comment_wrapper = f" ```{validate_comment}``` "
+        validate_comment_wrapper = f"\n```\n{validate_comment}\n``` "
         return False, validate_comment_wrapper, 1
 
 

--- a/qhub/provider/cicd/linter.py
+++ b/qhub/provider/cicd/linter.py
@@ -10,9 +10,9 @@ def qhub_validate(config):
     # Gather the output of `qhub validate`.
     print("Validate: info: validating QHub configuration in qhub-config.yaml")
 
-    def parse_validation(message: str):
+    def parse_validation(message):
         # this will just separate things for now, but can be enhanced
-        return message.split("ValidationError:")[1]
+        return str(message)
 
     try:
         verify(config)

--- a/qhub/provider/cicd/linter.py
+++ b/qhub/provider/cicd/linter.py
@@ -1,0 +1,99 @@
+import os
+import json
+import textwrap
+import pathlib
+import requests
+from qhub.schema import verify
+
+
+def qhub_validate(config):
+    # Gather the output of `qhub validate`.
+    print("Validate: info: validating QHub configuration in qhub-config.yaml")
+
+    def parse_validation(message: str):
+        # this will just separate things for now, but can be enhanced
+        return message.split("ValidationError:")[1]
+    try:
+        verify(config)
+        msg = "validate: info: successfully validated QHub configuration"
+        print(msg)
+        return True, msg, 1
+
+    except BaseException as e:
+        msg = "validate: error: failed to validate QHub configuration."
+        print(msg)
+        validate_comment = parse_validation(e.stderr.decode("utf-8"))
+        validate_comment_wrapper = f" ```{validate_comment}``` "
+        return False, validate_comment_wrapper, 0
+
+
+def generate_lint_message(config):
+
+    # prep for linting
+    pr_config = pathlib.Path("qhub-config.yaml")
+    # lint/validate qhub-config.yaml
+    all_pass, messages, validate_code = qhub_validate(config)
+
+    pass_lint = textwrap.dedent(
+        """
+            This is an automatic response from the QHub-cloud linter.
+            I just wanted to let you know that I linted your `qhub-config.yaml` in your PR and I didn't find any
+            problems.
+            """
+    )
+
+    # it should be better to parse this messages first
+    bad_lint = (
+        textwrap.dedent(
+            """
+            This is an automatic response from the QHub-cloud linter.
+            I just wanted to let you know that I linted your `qhub-config.yaml` in your PR and found some errors:\n"""
+        )
+        + f"{messages}"
+    )
+
+    if not pr_config:
+        status = "no configuration file"
+        message = textwrap.dedent(
+            """
+            This is an automatic response from the QHub-cloud linter.
+            I was trying to look for the `qhub-config.yaml` file to lint for you, but couldn't find any...
+            """
+        )
+
+    elif all_pass:
+        status = "Success"
+        message = pass_lint
+    else:
+        status = "Failure"
+        message = bad_lint
+
+    lint = {
+        "message": f"#### `qhub validate` {status} \n" + message,
+        "code": validate_code,
+    }
+    return lint
+
+
+def comment_on_pr(config):
+    lint = generate_lint_message(config)
+    message = lint["message"]
+    exitcode = lint["code"]
+
+    print(
+        "If the comment was not published, the following would "
+        "have been the message:\n{}".format(message)
+    )
+
+    # comment on PR
+    owner, repo_name = os.environ["REPO_NAME"].split("/")
+    pr_id = os.environ["PR_NUMBER"]
+
+    token = os.environ["GITHUB_TOKEN"]
+    url = f"https://api.github.com/repos/{owner}/{repo_name}/issues/{pr_id}/comments"
+
+    payload = {"body": message}
+    headers = {"Content-Type": "application/json", "Authorization": f"token {token}"}
+    requests.post(url=url, headers=headers, data=json.dumps(payload))
+
+    return exit(exitcode)

--- a/qhub/provider/cicd/linter.py
+++ b/qhub/provider/cicd/linter.py
@@ -13,6 +13,7 @@ def qhub_validate(config):
     def parse_validation(message: str):
         # this will just separate things for now, but can be enhanced
         return message.split("ValidationError:")[1]
+
     try:
         verify(config)
         msg = "validate: info: successfully validated QHub configuration"

--- a/qhub/provider/cicd/linter.py
+++ b/qhub/provider/cicd/linter.py
@@ -23,7 +23,7 @@ def qhub_validate(config):
     except BaseException as e:
         msg = "validate: error: failed to validate QHub configuration."
         print(msg)
-        validate_comment = parse_validation(e.stderr.decode("utf-8"))
+        validate_comment = parse_validation(e)
         validate_comment_wrapper = f" ```{validate_comment}``` "
         return False, validate_comment_wrapper, 0
 

--- a/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/qhub-linter.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/qhub-linter.yaml
@@ -7,6 +7,12 @@ on:
     paths:
       - "qhub-config.yaml"
 
+{%- if cookiecutter.QHUB_GH_BRANCH != '' %}
+env:
+  # Preserve dev branch so pip_install_qhub doesn't get overridden on next render.
+  # Although currently no deploy/render step in this workflow so should be OK.
+  QHUB_GH_BRANCH: {{ cookiecutter.QHUB_GH_BRANCH }}
+{% endif %}
 
 jobs:
   qhub-validate:

--- a/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/qhub-linter.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/qhub-linter.yaml
@@ -1,0 +1,33 @@
+name: "QHub validate linter"
+
+on:
+  pull_request:
+    branches:
+      - "{{ cookiecutter.ci_cd.branch }}"
+    paths:
+      - "qhub-config.yaml"
+
+
+jobs:
+  qhub-validate:
+    name: 'Qhub'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Infastructure'
+        uses: actions/checkout@master
+        with:
+          token: {{ '${{ secrets.REPOSITORY_ACCESS_TOKEN }}' }}
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install qhub
+        run: |
+          {{ cookiecutter.pip_install_qhub }}
+      - name: 'Qhub Linterfy'
+        env:
+          PR_NUMBER: {{ '${{ github.event.number }}' }}
+          REPO_NAME : {{ '${{ github.repository }}' }}
+          GITHUB_TOKEN: {{ '${{ secrets.REPOSITORY_ACCESS_TOKEN }}' }}
+        run: |
+          qhub validate qhub-config.yaml --enable-commenting


### PR DESCRIPTION
This approach aims to execute a specific file for linting called `linter.py`. Right now it only utilizes `qhub validate` (`verify(config)`), but we are able to put even more linting abilities to it in the future, without changing all the process.

close #379