### PR TITLE
Cloud Regions simplified

### DIFF
--- a/docs/source/02_get_started/02_setup.md
+++ b/docs/source/02_get_started/02_setup.md
@@ -73,16 +73,13 @@ How-To Guides section of the documentation.
 Please see these instructions for [creating an IAM
 role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create.html)
 with administrator permissions. Upon generation, the IAM role will provide a public **access
-key ID** and a **secret key** which will need to be added to the environment variables. Additionally, you will also need to
-set the [AWS region](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html)
-where you intend to deploy your QHub infrastructure.
+key ID** and a **secret key** which will need to be added to the environment variables.
 
 To define the environment variables paste the commands below with your respective keys.
 
 ```bash
 export AWS_ACCESS_KEY_ID="HAKUNAMATATA"
 export AWS_SECRET_ACCESS_KEY="iNtheJUng1etheMightyJUNgleTHEl10N51eEpsT0n1ghy;"
-export AWS_DEFAULT_REGION="eu-west-2"
 ```
 </details>
 

--- a/docs/source/02_get_started/04_configuration.md
+++ b/docs/source/02_get_started/04_configuration.md
@@ -359,7 +359,6 @@ To see available instance types refer to
 google_cloud_platform:
   project: test-test-test
   region: us-central1
-  zone: us-central1-c
   availability_zones: ["us-central1-c"]
   kubernetes_version: "1.18.16-gke.502"
   node_groups:

--- a/docs/source/03_tutorials_and_samples/1_project_setup_tutorial.md
+++ b/docs/source/03_tutorials_and_samples/1_project_setup_tutorial.md
@@ -96,7 +96,6 @@ Please see these instructions for [creating an IAM role] with admin permissions 
 
 - `AWS_ACCESS_KEY_ID`: The public key for an IAM account
 - `AWS_SECRET_ACCESS_KEY`: The Private key for an IAM account
-- `AWS_DEFAULT_REGION`: The region where you intend to deploy QHub
 
 #### 2.4.2 Digital Ocean
 

--- a/docs/source/04_how_to_guides/2_qhub-gcp-deploy_guide.md
+++ b/docs/source/04_how_to_guides/2_qhub-gcp-deploy_guide.md
@@ -91,7 +91,7 @@ Among the cloud service providers on which QHub can be deployed, GCP has the bes
 google_cloud_platform:
   project: <project_id>
   region: us-central1
-  availability_zones: ["us-central1-c"]
+  availability_zones: ["us-central1-a", "us-central1-b"]
   kubernetes_version: "1.14.10-gke.31"
   node_groups:
     general:

--- a/docs/source/04_how_to_guides/2_qhub-gcp-deploy_guide.md
+++ b/docs/source/04_how_to_guides/2_qhub-gcp-deploy_guide.md
@@ -91,7 +91,6 @@ Among the cloud service providers on which QHub can be deployed, GCP has the bes
 google_cloud_platform:
   project: <project_id>
   region: us-central1
-  zone: us-central1-c
   availability_zones: ["us-central1-c"]
   kubernetes_version: "1.14.10-gke.31"
   node_groups:

--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -119,7 +119,6 @@ DIGITAL_OCEAN = {
 GOOGLE_PLATFORM = {
     "project": "PLACEHOLDER",
     "region": "us-central1",
-    "zone": "us-central1-c",
     "availability_zones": ["us-central1-c"],
     "kubernetes_version": "1.18.16-gke.502",
     "node_groups": {

--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -380,8 +380,6 @@ def render_config(
             "hub_subtitle"
         ] = "Autoscaling Compute Environment on Amazon Web Services"
         config["amazon_web_services"] = AMAZON_WEB_SERVICES
-        if "AWS_DEFAULT_REGION" in os.environ:
-            config["amazon_web_services"]["region"] = os.environ["AWS_DEFAULT_REGION"]
         if kubernetes_version:
             config["amazon_web_services"]["kubernetes_version"] = kubernetes_version
     elif cloud_provider == "local":
@@ -455,7 +453,6 @@ def github_auto_provision(config, owner, repo):
             for name in {
                 "AWS_ACCESS_KEY_ID",
                 "AWS_SECRET_ACCESS_KEY",
-                "AWS_DEFAULT_REGION",
             }:
                 github.update_secret(owner, repo, name, os.environ[name])
         elif config["provider"] == "gcp":

--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -119,7 +119,6 @@ DIGITAL_OCEAN = {
 GOOGLE_PLATFORM = {
     "project": "PLACEHOLDER",
     "region": "us-central1",
-    "availability_zones": ["us-central1-c"],
     "kubernetes_version": "1.18.16-gke.502",
     "node_groups": {
         "general": {"instance": "n1-standard-2", "min_nodes": 1, "max_nodes": 1},

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -173,7 +173,7 @@ class GoogleCloudPlatformProvider(Base):
     project: str
     region: str
     zone: typing.Optional[str]  # No longer used
-    availability_zones: typing.List[str]
+    availability_zones: typing.Optional[typing.List[str]]  # Genuinely optional
     kubernetes_version: str
     node_groups: typing.Dict[str, NodeGroup]
 

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -172,7 +172,7 @@ class DigitalOceanProvider(Base):
 class GoogleCloudPlatformProvider(Base):
     project: str
     region: str
-    zone: str
+    zone: typing.Optional[str]  # No longer used
     availability_zones: typing.List[str]
     kubernetes_version: str
     node_groups: typing.Dict[str, NodeGroup]

--- a/qhub/template/cookiecutter.json
+++ b/qhub/template/cookiecutter.json
@@ -68,7 +68,6 @@
     "google_cloud_platform": {
         "project": null,
         "region": null,
-        "zone": null,
         "availability_zones": [],
         "kubernetes_version": null,
         "node_groups": {

--- a/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/image.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/image.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           aws-access-key-id: {{ '${{ secrets.AWS_ACCESS_KEY_ID }}' }}
           aws-secret-access-key: {{ '${{ secrets.AWS_SECRET_ACCESS_KEY }}' }}
-          aws-region: {{ '${{ secrets.AWS_DEFAULT_REGION }}' }}
+          aws-region: {{ cookiecutter.amazon_web_services.region }}
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/gcp.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/gcp.tf
@@ -3,6 +3,9 @@ provider "google" {
   region  = "{{ cookiecutter.google_cloud_platform.region }}"
 }
 
+data "google_compute_zones" "gcpzones" {
+  region = "{{ cookiecutter.google_cloud_platform.region }}"
+}
 
 module "registry-jupyterhub" {
   source = "./modules/gcp/registry"
@@ -15,7 +18,7 @@ module "kubernetes" {
   name     = local.cluster_name
   location = var.region
 
-  availability_zones = var.availability_zones
+  availability_zones = length(var.availability_zones) >= 1 ? var.availability_zones : [data.google_compute_zones.gcpzones.names[0]]
 
   additional_node_group_roles = [
     "roles/storage.objectViewer",

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/gcp.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/gcp.tf
@@ -1,7 +1,6 @@
 provider "google" {
   project = "{{ cookiecutter.google_cloud_platform.project }}"
   region  = "{{ cookiecutter.google_cloud_platform.region }}"
-  zone    = "{{ cookiecutter.google_cloud_platform.zone }}"
 }
 
 

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/gcp/kubernetes/main.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/gcp/kubernetes/main.tf
@@ -12,6 +12,12 @@ resource "google_container_cluster" "main" {
   # node pool and immediately delete it.
   remove_default_node_pool = true
   initial_node_count       = 1
+
+  lifecycle {
+    ignore_changes = [
+      node_locations
+    ]
+  }
 }
 
 resource "google_container_node_pool" "main" {

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/variables.tf
@@ -17,11 +17,7 @@ variable "region" {
 variable "availability_zones" {
   description = "AWS availability zones within AWS region"
   type        = list(string)
-{%- if cookiecutter.amazon_web_services.availability_zones is defined %}
-  default     = {{ cookiecutter.amazon_web_services.availability_zones | jsonify }}
-{%- else %}
-  default     = []
-{%- endif %}
+  default     = {{ cookiecutter.amazon_web_services.availability_zones | default([],true) | jsonify }}
 }
 
 variable "vpc_cidr_block" {
@@ -38,7 +34,7 @@ variable "region" {
 variable "availability_zones" {
   description = "GCP availability zones within region"
   type        = list(string)
-  default     = {{ cookiecutter.google_cloud_platform.availability_zones | jsonify }}
+  default     = {{ cookiecutter.google_cloud_platform.availability_zones | default([],true) | jsonify }}
 }
 {% elif cookiecutter.provider == "azure" %}
 variable "region" {

--- a/qhub/template/{{ cookiecutter.repo_directory }}/terraform-state/main.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/terraform-state/main.tf
@@ -18,7 +18,6 @@ module "terraform-state" {
 provider "google" {
   project = "{{ cookiecutter.google_cloud_platform.project }}"
   region  = "{{ cookiecutter.google_cloud_platform.region }}"
-  zone    = "{{ cookiecutter.google_cloud_platform.zone }}"
 }
 
 module "terraform-state" {

--- a/qhub/utils.py
+++ b/qhub/utils.py
@@ -97,7 +97,6 @@ def check_cloud_credentials(config):
         for variable in {
             "AWS_ACCESS_KEY_ID",
             "AWS_SECRET_ACCESS_KEY",
-            "AWS_DEFAULT_REGION",
         }:
             if variable not in os.environ:
                 raise ValueError(


### PR DESCRIPTION
AWS_DEFAULT_REGION no longer needed.

For GCP, `zone` is removed from qhub-config.yaml, and availability_zones is optional - pulls default from Google if not specified.

To avoid clusters being torn down inadvertently, once set availability_zones cannot be changed (this was the same for the similar PR I did for AWS).