### PR TITLE
Secure dask dashboard behind forwardauth

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
@@ -198,6 +198,10 @@ module "qhub" {
 
   dask_gateway_extra_config = file("dask_gateway_config.py.j2")
 
+  forwardauth-jh-client-id      = local.forwardauth-jh-client-id
+  forwardauth-jh-client-secret  = random_password.forwardauth-jhsecret.result
+  forwardauth-callback-url-path = local.forwardauth-callback-url-path
+
   depends_on = [
     module.kubernetes-ingress
   ]
@@ -215,3 +219,18 @@ module "prefect" {
   prefect_token        = var.prefect_token
 }
 {% endif -%}
+
+resource "random_password" "forwardauth-jhsecret" {
+  length  = 32
+  special = false
+}
+
+module "forwardauth" {
+  source       = "./modules/kubernetes/forwardauth"
+  namespace    = var.environment
+  external-url = var.endpoint
+
+  jh-client-id      = local.forwardauth-jh-client-id
+  jh-client-secret  = random_password.forwardauth-jhsecret.result
+  callback-url-path = local.forwardauth-callback-url-path
+}

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/locals.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/locals.tf
@@ -65,4 +65,7 @@ locals {
 {% endif %}
     }
   }
+
+  forwardauth-jh-client-id      = "forwardauthjupyterhubserviceclient"
+  forwardauth-callback-url-path = "/forwardauth/_oauth"
 }

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/forwardauth/main.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/forwardauth/main.tf
@@ -1,0 +1,131 @@
+resource "kubernetes_service" "forwardauth-service" {
+  metadata {
+    name      = "forwardauth-service"
+    namespace = var.namespace
+  }
+  spec {
+    selector = {
+      app = kubernetes_deployment.forwardauth-deployment.spec.0.template.0.metadata[0].labels.app
+    }
+    port {
+      port        = 4181
+      target_port = 4181
+    }
+
+    type = "ClusterIP"
+  }
+}
+
+resource "random_password" "forwardauth_cookie_secret" {
+  length  = 32
+  special = false
+}
+
+resource "kubernetes_deployment" "forwardauth-deployment" {
+  metadata {
+    name      = "forwardauth-deployment"
+    namespace = var.namespace
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = "forwardauth-pod"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "forwardauth-pod"
+        }
+      }
+
+      spec {
+
+        container {
+          name  = "forwardauth-container"
+          image = "thomseddon/traefik-forward-auth:2.2.0"
+
+          env {
+            name  = "PROVIDERS_GENERIC_OAUTH_AUTH_URL"
+            value = "https://${var.external-url}/hub/api/oauth2/authorize"
+          }
+
+          env {
+            name  = "PROVIDERS_GENERIC_OAUTH_TOKEN_URL"
+            value = "http://proxy-public.${var.namespace}/hub/api/oauth2/token"
+          }
+
+          env {
+            name  = "PROVIDERS_GENERIC_OAUTH_USER_URL"
+            value = "http://proxy-public.${var.namespace}/hub/api/user"
+          }
+
+          env {
+            name  = "PROVIDERS_GENERIC_OAUTH_CLIENT_ID"
+            value = var.jh-client-id
+          }
+
+          env {
+            name  = "PROVIDERS_GENERIC_OAUTH_CLIENT_SECRET"
+            value = var.jh-client-secret
+          }
+
+          env {
+            name  = "SECRET"
+            value = random_password.forwardauth_cookie_secret.result
+          }
+
+          env {
+            name  = "DEFAULT_PROVIDER"
+            value = "generic-oauth"
+          }
+
+          env {
+            name  = "URL_PATH"
+            value = var.callback-url-path
+          }
+
+          env {
+            name  = "LOG_LEVEL"
+            value = "trace"
+          }
+
+          port {
+            container_port = 4181
+          }
+
+        }
+
+      }
+    }
+  }
+}
+
+resource "kubernetes_manifest" "forwardauth-middleware" {
+  # This version of the middleware is primarily for the forwardauth service
+  # itself, so the callback _oauth url can be centalised (not just under e.g. /someservice/_oauth).
+  # This middleware is in the root namespace, someservice may have its own.
+
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "traefik.containo.us/v1alpha1"
+    kind       = "Middleware"
+    metadata = {
+      name      = "traefik-forward-auth"
+      namespace = var.namespace
+    }
+    spec = {
+      forwardAuth = {
+        address = "http://forwardauth-service:4181"
+        authResponseHeaders = [
+          "X-Forwarded-User"
+        ]
+      }
+    }
+  }
+}

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/forwardauth/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/forwardauth/variables.tf
@@ -1,0 +1,24 @@
+variable "namespace" {
+  description = "Namespace to deploy forwardauth"
+  type        = string
+}
+
+variable "external-url" {
+  description = "External domain where QHub is accessible"
+  type        = string
+}
+
+variable "jh-client-id" {
+  description = "JupyterHub service client ID"
+  type        = string
+}
+
+variable "jh-client-secret" {
+  description = "JupyterHub service client secret"
+  type        = string
+}
+
+variable "callback-url-path" {
+  description = "Path of Callback URL"
+  type        = string
+}

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/dask-gateway/middleware.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/dask-gateway/middleware.tf
@@ -18,6 +18,8 @@ resource "kubernetes_manifest" "gateway-middleware" {
   }
 }
 
+# Create one chain middleware for the IngressRoutes that will be dynamically created by Dask Gateway
+# The chain combines traefik-forward-auth and stripprefix middleware defined below.
 
 resource "kubernetes_manifest" "cluster-middleware" {
   provider = kubernetes-alpha
@@ -27,6 +29,33 @@ resource "kubernetes_manifest" "cluster-middleware" {
     kind       = "Middleware"
     metadata = {
       name      = "qhub-dask-gateway-cluster"
+      namespace = var.namespace
+    }
+    spec = {
+      chain = {
+        middlewares = [
+          {
+            name      = "traefik-forward-auth"
+            namespace = var.namespace
+          },
+          {
+            name      = kubernetes_manifest.cluster-middleware-stripprefix.manifest.metadata.name
+            namespace = var.namespace
+          }
+        ]
+      }
+    }
+  }
+}
+
+resource "kubernetes_manifest" "cluster-middleware-stripprefix" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "traefik.containo.us/v1alpha1"
+    kind       = "Middleware"
+    metadata = {
+      name      = "qhub-dask-gateway-cluster-stripprefix"
       namespace = var.namespace
     }
     spec = {

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/meta/qhub/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/meta/qhub/variables.tf
@@ -99,3 +99,21 @@ variable "certificate-secret-name" {
   type        = string
   default     = ""
 }
+
+variable "forwardauth-jh-client-id" {
+  description = "JupyterHub Client ID for use with ForwardAuth"
+  type        = string
+  default     = ""
+}
+
+variable "forwardauth-jh-client-secret" {
+  description = "JupyterHub Client Secret for use with ForwardAuth"
+  type        = string
+  default     = ""
+}
+
+variable "forwardauth-callback-url-path" {
+  description = "Callback URL Path for ForwardAuth"
+  type        = string
+  default     = ""
+}

--- a/qhub/template/{{ cookiecutter.repo_directory }}/templates/jupyterhub_config.py.j2
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/templates/jupyterhub_config.py.j2
@@ -62,6 +62,8 @@ QHUB_USER_MAPPING = {{ cookiecutter.security.users }}
 QHUB_GROUP_MAPPING = {{ cookiecutter.security.groups }}
 QHUB_PROFILES = {{ cookiecutter.profiles.jupyterlab }}
 
+import escapism
+import string
 
 def qhub_generate_nss_files():
     passwd = []
@@ -142,11 +144,17 @@ def qhub_configure_profile(username, safe_username, profile):
     profile['kubespawner_override']['gid'] = primary_gid
     profile['kubespawner_override']['supplemental_gids'] = secondary_gids
     profile['kubespawner_override']['fs_gid'] = primary_gid
+
+    # Cost monitoring labels
+    k8s_safe_chars = set(string.ascii_lowercase + string.digits + '.-_')
+    k8s_safe_username = escapism.escape(username.lower().replace('@', '_'), safe=k8s_safe_chars, escape_char='-')
+    profile['kubespawner_override']['extra_labels'] = {
+        'owner': k8s_safe_username,
+        'team': user['primary_group']
+    }
     return profile
 
 def qhub_list_available_profiles(username):
-    import escapism
-    import string
     safe_chars = set(string.ascii_lowercase + string.digits)
     safe_username = escapism.escape(username, safe=safe_chars, escape_char='-').lower()
 
@@ -234,3 +242,4 @@ c.{{ cookiecutter.security.authentication.authentication_class.split('.')[-1] }}
 {% endfor %}
 
 {% endif %}
+


### PR DESCRIPTION
Uses forwardauth to protect dask dashboards behind JupyterHub auth using a new oauth client.

Note any JupyterHub user can access any dashboard.