### PR TITLE
make message for schema validation failure more informative

### DIFF
--- a/qhub/cli/__init__.py
+++ b/qhub/cli/__init__.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import sys
+from pydantic.error_wrappers import ValidationError
 
 from qhub.cli.deploy import create_deploy_subcommand
 from qhub.cli.initialize import create_init_subcommand
@@ -39,6 +40,12 @@ def cli(args):
 
     try:
         args.func(args)
+    except ValidationError as valerr:
+        sys.exit(
+            "Error: The schema validation of the qhub-config.yaml failed."
+            " The following error message may be helpful in determining what went wrong:\n\n"
+            + str(valerr)
+        )
     except ValueError as ve:
         sys.exit("\nProblem encountered: " + str(ve) + "\n")
     except TerraformException:

--- a/qhub/cli/validate.py
+++ b/qhub/cli/validate.py
@@ -29,4 +29,12 @@ def handle_validate(args):
         # for PR's only
         comment_on_pr(config)
     else:
-        verify(config)
+        try:
+            verify(config)
+        except pydantic.error_wrappers.ValidationError as err:
+            print(err)
+            print(
+                "Error: The schema validation of the qhub-config.yaml failed."
+                " The above error message may be helpful in determining what went wrong."
+            )
+            sys.exit(1)

--- a/qhub/cli/validate.py
+++ b/qhub/cli/validate.py
@@ -1,14 +1,20 @@
 import pathlib
 
-from pydantic.error_wrappers import ValidationError
 from ruamel import yaml
 from qhub.schema import verify
 from qhub.provider.cicd.linter import comment_on_pr
-import sys
+
 
 def create_validate_subcommand(subparser):
     subparser = subparser.add_parser("validate")
-    subparser.add_argument("config", help="qhub configuration")
+    subparser.add_argument(
+        "configdeprecated",
+        help="qhub configuration yaml file (deprecated - please pass in as -c/--config flag)",
+        nargs="?",
+    )
+    subparser.add_argument(
+        "-c", "--config", help="qhub configuration yaml file", required=False
+    )
     subparser.add_argument(
         "--enable-commenting", help="Turn on PR commenting", action="store_true"
     )
@@ -16,7 +22,18 @@ def create_validate_subcommand(subparser):
 
 
 def handle_validate(args):
-    config_filename = pathlib.Path(args.config)
+    if args.configdeprecated and args.config:
+        raise ValueError(
+            "Please pass in -c/--config flag specifying your qhub-config.yaml file, and do NOT pass it as a standalone argument"
+        )
+
+    config_filename = args.config or args.configdeprecated
+    if not config_filename:
+        raise ValueError(
+            "Please pass in a qhub-config.yaml filename using the -c/--config argument"
+        )
+
+    config_filename = pathlib.Path(args.config or args.configdeprecated)
     if not config_filename.is_file():
         raise ValueError(
             f"passed in configuration filename={config_filename} must exist"
@@ -29,12 +46,4 @@ def handle_validate(args):
         # for PR's only
         comment_on_pr(config)
     else:
-        try:
-            verify(config)
-        except ValidationError as err:
-            print(err)
-            print(
-                "Error: The schema validation of the qhub-config.yaml failed."
-                " The above error message may be helpful in determining what went wrong."
-            )
-            sys.exit(1)
+        verify(config)

--- a/qhub/cli/validate.py
+++ b/qhub/cli/validate.py
@@ -1,10 +1,10 @@
 import pathlib
 
+from pydantic.error_wrappers import ValidationError
 from ruamel import yaml
-
 from qhub.schema import verify
 from qhub.provider.cicd.linter import comment_on_pr
-
+import sys
 
 def create_validate_subcommand(subparser):
     subparser = subparser.add_parser("validate")
@@ -31,7 +31,7 @@ def handle_validate(args):
     else:
         try:
             verify(config)
-        except pydantic.error_wrappers.ValidationError as err:
+        except ValidationError as err:
             print(err)
             print(
                 "Error: The schema validation of the qhub-config.yaml failed."

--- a/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/qhub-linter.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/qhub-linter.yaml
@@ -36,4 +36,4 @@ jobs:
           REPO_NAME : {{ '${{ github.repository }}' }}
           GITHUB_TOKEN: {{ '${{ secrets.REPOSITORY_ACCESS_TOKEN }}' }}
         run: |
-          qhub validate qhub-config.yaml --enable-commenting
+          qhub validate --config qhub-config.yaml --enable-commenting


### PR DESCRIPTION
This provides a little more context for the user upon failure during schema
validation of the qhub config yaml (example is
https://github.com/Quansight/qhub/issues/593). I found this error message
a little too impenetrable... lack of experience no doubt but this might be
helpful to the next poor unfortunate.