### PR TITLE
Add ability to set environment vars to Dask workers

### DIFF
--- a/docs/source/03_tutorials_and_samples/03_dask_gateway_usage.md
+++ b/docs/source/03_tutorials_and_samples/03_dask_gateway_usage.md
@@ -76,6 +76,39 @@ z.compute()
 
 If a result was returned your cluster is working!
 
+## Cluster Options
+
+Dask Gateway allow users to configure their clusters via cluster options, here
+are some configuration options exposed in QHub's Dask Gateway deployment.
+
+* Get cluster options
+
+```python
+import dask_gateway
+gateway = dask_gateway.Gateway()
+options = gateway.cluster_options()
+```
+
+### Setting Environment variables for Dask Workers
+
+```python
+options.environment_vars = {
+    "ENV_VAR_1": "VALUE_1",
+    "ENV_VAR_2": "VALUE_2",
+}
+```
+
+### Setting Conda Environment for Dask Workers
+
+```python
+options.conda_environment = "tensorflow"
+```
+
+Note: The above configurations options are valid for QHub's Dask Gateway deployment,
+these might be different for a non QHub deployments, like say Pangeo's
+Dask Gateway deployment.
+
+
 ## Accessing Cluster Outside of QHub
 
 A long requested feature was the ability to access a dask cluster from

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/dask_gateway_config.py.j2
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/dask_gateway_config.py.j2
@@ -13,14 +13,15 @@ def worker_profile(options):
     config['worker_cmd'] = '/opt/conda-run-worker'
     config['scheduler_cmd'] = '/opt/conda-run-scheduler'
     config['environment'] = {
-        'CONDA_ENVIRONMENT': options.environment
+        **options.environment_vars,
+        'CONDA_ENVIRONMENT': options.conda_environment
     }
     return config
 
 # Expose a list of profiles for workers
 c.Backend.cluster_options = Options(
     Select(
-        "environment",
+        "conda_environment",
         environments,
         default=environments[0],
         label='Environment',
@@ -31,5 +32,6 @@ c.Backend.cluster_options = Options(
         default='{{ cookiecutter.profiles.dask_worker.keys() | list() | first() }}',
         label="Cluster Profile",
     ),
+    Mapping("environment_vars", {}, label="Environment Variables"),
     handler=worker_profile,
 )

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/dask_gateway_config.py.j2
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/dask_gateway_config.py.j2
@@ -1,4 +1,4 @@
-from dask_gateway_server.options import Options, Select
+from dask_gateway_server.options import Options, Select, Mapping
 
 # A mapping from profile name to configuration overrides
 profiles = {{ cookiecutter.profiles.dask_worker }}


### PR DESCRIPTION
Fixes #599 

<img width="852" alt="Screenshot 2021-05-24 at 23 01 24" src="https://user-images.githubusercontent.com/5647941/119385976-8a130600-bce4-11eb-98ee-f31d0e1d68a2.png">

Here is a working deployed example:
https://nbviewer.jupyter.org/gist/aktech/4ec2b8cd275a0e3205e0bb76365a7d3c