### PR TITLE
Traitlets fix

### DIFF
--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -235,7 +235,7 @@ DEFAULT_ENVIRONMENTS = {
             "voila >=0.2.7",
             "streamlit >=0.76",
             "dash >=1.19",
-            "cdsdashboards-singleuser >=0.5.6",
+            "cdsdashboards-singleuser >=0.5.7",
         ],
     },
 }

--- a/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterhub/environment.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterhub/environment.yaml
@@ -2,12 +2,12 @@ name: base
 channels:
   - conda-forge
 dependencies:
- - pip
- - jupyterhub>=1.3.0
- - bcrypt
- - oauthenticator
- - escapism
- - cdsdashboards>=0.5.6
+ - pip==21.1.2
+ - jupyterhub==1.4.1
+ - jupyterhub-kubespawner==1.0.0
+ - bcrypt==3.2.0
+ - oauthenticator==14.0.0
+ - escapism==1.0.1
+ - cdsdashboards==0.5.7
  - pip:
-   - jupyterhub-kubespawner >= 0.16.1
-   - qhub-jupyterhub-theme >= 0.3.1
+   - qhub-jupyterhub-theme==0.3.1

--- a/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterlab/environment.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterlab/environment.yaml
@@ -26,7 +26,7 @@ dependencies:
  - pyviz_comms >=2.0.1
 
  # cds dashboards
- - cdsdashboards-singleuser >=0.5.6
+ - cdsdashboards-singleuser >=0.5.7
  - jhsingle-native-proxy >=0.7.6
 
  # viz tools


### PR DESCRIPTION
Traitlets >= 5.0 seems to have a backwards-incompatibility that affected the VariableSpawner used in cdsdashboards.

This works around it.

Closes #602 