### PR TITLE
Terraform refresh before destroy to avoid failing destroy

### DIFF
--- a/qhub/destroy.py
+++ b/qhub/destroy.py
@@ -19,6 +19,7 @@ def destroy_configuration(config, skip_remote_state_provision=False):
 
         # 02 Remove all infrastructure
         terraform.init(directory="infrastructure")
+        terraform.refresh(directory="infrastructure")
         terraform.destroy(directory="infrastructure")
 
         # 03 Remove terraform backend remote state bucket

--- a/qhub/provider/terraform.py
+++ b/qhub/provider/terraform.py
@@ -105,6 +105,16 @@ def tfimport(addr, id, directory=None):
         )
 
 
+def refresh(directory=None):
+    logger.info(f"terraform refresh directory={directory}")
+    command = [
+        "refresh",
+    ]
+
+    with timer(logger, "terraform refresh"):
+        run_terraform_subprocess(command, cwd=directory, prefix="terraform")
+
+
 def destroy(directory=None):
     logger.info(f"terraform destroy directory={directory}")
     command = [


### PR DESCRIPTION
The terraform destroy fails on AWS if there is a significant delay between apply and destroy. This is why it was not caught in the integration tests.

The primary reason for this is in terraform >= 0.14, terraform doesn't refreshes the terraform state before generating a plan to destroy resources. This PR runs the refresh before destroy in order to cleanly destroy everything.