### PR TITLE
Allow explicit ci-provider=none

### DIFF
--- a/docs/source/02_get_started/03_usage.md
+++ b/docs/source/02_get_started/03_usage.md
@@ -44,7 +44,7 @@ allow to configure the deployment:
   more details see official Cloud provider docs on naming policies and check our docs on [naming convention](#project-naming-convention).
 - `--domain`: base domain for your cluster. This pattern is also applicable if you are setting your own DNS through a different provider.
   + `jupyter.qhub.dev` is the domain registered on CloudFlare. In case you chose not to use Cloudflare, skip this flag.
-- `--ci-provider`: specifies what provider to use for CI/CD. Currently, only supports GitHub Actions.
+- `--ci-provider`: specifies what provider to use for CI/CD. Currently, supports GitHub Actions, GitLab CI, or none.
 - `--auth-provider`: This will set configuration file to use the specified provider for authentication.
 - `--auth-auto-provision`: This will automatically create and configure an application using OAuth.
 - `--repository`: Repository name that will be used to store the Infrastructure-as-Code on GitHub.

--- a/docs/source/03_tutorials_and_samples/1_project_setup_tutorial.md
+++ b/docs/source/03_tutorials_and_samples/1_project_setup_tutorial.md
@@ -130,7 +130,7 @@ The next step is to run `qhub init` to generate the configuration file `qhub-con
 
 - `--project`: Chose a name consisting of lowercase letters and numbers only and is between 3 and 16 characters long. IE `testcluster`
 - `--domain`: This is the base domain for your cluster IE `test.qhub.dev`
-- `--ci-provider`: This specifies what provider to use for ci-cd. Currently, github-actions is supported.
+- `--ci-provider`: This specifies what provider to use for ci-cd (optional). Currently, `github-actions`, `gitlab-ci`, or `none` are supported.
 - `--auth-provider`: This will set configuration file to use auth0 for authentication
 - `--auth-auto-provision`: This will automatically create and configure an auth0 application
 - `--repository`: The repository name that will be used to store the infrastructure as code

--- a/qhub/cli/initialize.py
+++ b/qhub/cli/initialize.py
@@ -22,7 +22,7 @@ def create_init_subcommand(subparser):
     )
     subparser.add_argument(
         "--ci-provider",
-        choices=["github-actions", "gitlab-ci"],
+        choices=["github-actions", "gitlab-ci", "none"],
         help="continuous integration to use for infrastructure as code",
     )
     subparser.add_argument(

--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -258,7 +258,7 @@ def render_config(
     config = BASE_CONFIGURATION
     config["provider"] = cloud_provider
 
-    if ci_provider is not None:
+    if ci_provider is not None and ci_provider != "none":
         config["ci_cd"] = {"type": ci_provider, "branch": "main"}
 
     if terraform_state is not None:

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -29,6 +29,7 @@ class ProviderEnum(str, enum.Enum):
 class CiEnum(str, enum.Enum):
     github_actions = "github-actions"
     gitlab_ci = "gitlab-ci"
+    none = "none"
 
 
 class AuthenticationEnum(str, enum.Enum):


### PR DESCRIPTION
Can explicitly provide --ci-provider=none to qhub init (don't have to completely omit the parameter).

This makes integration tests easier.