### PR TITLE
Rename qhub-dask-gateway-cluster to -chain

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/dask-gateway/controler.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/dask-gateway/controler.tf
@@ -9,8 +9,8 @@ resource "kubernetes_config_map" "controller" {
       "${path.module}/templates/controller_config.py", {
         gateway_service_name                 = kubernetes_service.gateway.metadata.0.name
         gateway_service_namespace            = kubernetes_service.gateway.metadata.0.namespace
-        gateway_cluster_middleware_name      = kubernetes_manifest.cluster-middleware.manifest.metadata.name
-        gateway_cluster_middleware_namespace = kubernetes_manifest.cluster-middleware.manifest.metadata.namespace
+        gateway_cluster_middleware_name      = kubernetes_manifest.chain-middleware.manifest.metadata.name
+        gateway_cluster_middleware_namespace = kubernetes_manifest.chain-middleware.manifest.metadata.namespace
         gateway                              = var.gateway
         controller                           = var.controller
     })

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/dask-gateway/middleware.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/dask-gateway/middleware.tf
@@ -21,14 +21,14 @@ resource "kubernetes_manifest" "gateway-middleware" {
 # Create one chain middleware for the IngressRoutes that will be dynamically created by Dask Gateway
 # The chain combines traefik-forward-auth and stripprefix middleware defined below.
 
-resource "kubernetes_manifest" "cluster-middleware" {
+resource "kubernetes_manifest" "chain-middleware" {
   provider = kubernetes-alpha
 
   manifest = {
     apiVersion = "traefik.containo.us/v1alpha1"
     kind       = "Middleware"
     metadata = {
-      name      = "qhub-dask-gateway-cluster"
+      name      = "qhub-dask-gateway-chain"  # Updated name to -chain from -cluster to avoid upgrade confusion
       namespace = var.namespace
     }
     spec = {

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/dask-gateway/middleware.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/dask-gateway/middleware.tf
@@ -28,7 +28,7 @@ resource "kubernetes_manifest" "chain-middleware" {
     apiVersion = "traefik.containo.us/v1alpha1"
     kind       = "Middleware"
     metadata = {
-      name      = "qhub-dask-gateway-chain"  # Updated name to -chain from -cluster to avoid upgrade confusion
+      name      = "qhub-dask-gateway-chain" # Updated name to -chain from -cluster to avoid upgrade confusion
       namespace = var.namespace
     }
     spec = {


### PR DESCRIPTION
Closes #636 

There was a problem in upgrading a qhub that had the old definition of qhub-dask-gateway-cluster because Terraform wasn't updating the type to a 'chain' middleware.