### PR TITLE
Change subned cidr mask

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/aws/network/main.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/aws/network/main.tf
@@ -12,7 +12,7 @@ resource "aws_subnet" "main" {
   count = length(var.aws_availability_zones)
 
   availability_zone       = var.aws_availability_zones[count.index]
-  cidr_block              = cidrsubnet(var.vpc_cidr_block, 8, count.index)
+  cidr_block              = cidrsubnet(var.vpc_cidr_block, 4, count.index)
   vpc_id                  = aws_vpc.main.id
   map_public_ip_on_launch = true
 

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/aws/network/main.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/aws/network/main.tf
@@ -12,7 +12,7 @@ resource "aws_subnet" "main" {
   count = length(var.aws_availability_zones)
 
   availability_zone       = var.aws_availability_zones[count.index]
-  cidr_block              = cidrsubnet(var.vpc_cidr_block, 4, count.index)
+  cidr_block              = cidrsubnet(var.vpc_cidr_block, var.vpc_cidr_newbits, count.index)
   vpc_id                  = aws_vpc.main.id
   map_public_ip_on_launch = true
 

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/aws/network/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/aws/network/variables.tf
@@ -33,6 +33,12 @@ variable "aws_availability_zones" {
 }
 
 variable "vpc_cidr_block" {
-  description = "VPC cidr for subnets to inside of"
+  description = "VPC cidr for subnets to be inside of"
   type        = string
+}
+
+variable "vpc_cidr_newbits" {
+  description = "VPC cidr number of bits to support 2^N subnets"
+  type        = number
+  default     = 4
 }


### PR DESCRIPTION
Changes the network mask for the QHub subnets on AWS from `x.x.x.x/24` to `x.x.x.x/20` to increase the number of available IP addresses