### PR TITLE
ADD prefect optional field

### DIFF
--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -280,6 +280,7 @@ class Main(Base):
         TerraformModules
     ]  # No longer used, so ignored, but could still be in qhub-config.yaml
     certificate: Certificate
+    prefect: typing.Optional[bool]
     cdsdashboards: CDSDashboards
     security: Security
     default_images: DefaultImages


### PR DESCRIPTION
This should fix schema validation error for `prefect: true` new field in the `qhub-config.yml` file.

This seems to be the current error message when attempt to deploy QHub with prefect in it:

```bash
Problem encountered: 1 validation error for Main
prefect
  extra fields not permitted (type=value_error.extra)
```

See [discussion](https://github.com/Quansight/qhub/pull/641#issuecomment-859101173) 

Closes #114