### PR TITLE
Make load balancer ip and annotations configurable

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
       - name: 'Checkout Infrastructure'
         uses: actions/checkout@main

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -1,5 +1,6 @@
 import enum
 import typing
+import ipaddress
 
 import pydantic
 from pydantic import validator, root_validator
@@ -350,6 +351,8 @@ class Main(Base):
     provider: ProviderEnum
     ci_cd: typing.Optional[CICD]
     domain: str
+    load_balancer_ip: typing.Optional[ipaddress.IPv4Address]
+    load_balancer_annotations: typing.Optional[typing.Dict[str, str]]
     terraform_state: typing.Optional[TerraformState]
     terraform_modules: typing.Optional[
         TerraformModules

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
@@ -164,6 +164,18 @@ module "kubernetes-ingress" {
 
   node-group = local.node_groups.general
 
+{% if cookiecutter.load_balancer_ip is defined %}
+  load-balancer-ip = "{{ cookiecutter.load_balancer_ip }}"
+{% endif %}
+
+{% if cookiecutter.load_balancer_annotations is defined %}
+  load-balancer-annotations = {
+{% for key, value in cookiecutter.load_balancer_annotations.items() %}
+    "{{ "%s" | format(key) }}" = "{{ value }}"
+{% endfor %}
+  }
+{% endif %}
+
 {% if cookiecutter.certificate.type == "lets-encrypt" %}
   enable-certificates = true
   acme-email          = "{{ cookiecutter.certificate.acme_email }}"

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/ingress/main.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/ingress/main.tf
@@ -59,8 +59,9 @@ resource "kubernetes_service" "main" {
   wait_for_load_balancer = true
 
   metadata {
-    name      = "${var.name}-traefik-ingress"
-    namespace = var.namespace
+    name        = "${var.name}-traefik-ingress"
+    namespace   = var.namespace
+    annotations = var.load-balancer-annotations
   }
 
   spec {
@@ -104,6 +105,8 @@ resource "kubernetes_service" "main" {
     }
 
     type = "LoadBalancer"
+
+    load_balancer_ip = var.load-balancer-ip
   }
 }
 

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/ingress/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/ingress/variables.tf
@@ -32,16 +32,19 @@ variable "traefik-image" {
 
 variable "loglevel" {
   description = "traefik log level"
+  type        = string
   default     = "WARN"
 }
 
 variable "enable-certificates" {
   description = "Enable certificates"
+  type        = bool
   default     = false
 }
 
 variable "acme-email" {
   description = "ACME server email"
+  type        = string
   default     = "costrouchov@quansight.com"
 }
 
@@ -50,5 +53,18 @@ variable "acme-server" {
   # for testing use the letencrypt staging server
   #  - staging:    https://acme-staging-v02.api.letsencrypt.org/directory
   #  - production: https://acme-v02.api.letsencrypt.org/directory
+  type    = string
   default = "https://acme-staging-v02.api.letsencrypt.org/directory"
+}
+
+variable "load-balancer-ip" {
+  description = "Fixed load balancer IP Address"
+  type        = string
+  default     = null
+}
+
+variable "load-balancer-annotations" {
+  description = "Annotations to apply to load balancer"
+  type        = map(string)
+  default     = {}
 }


### PR DESCRIPTION
Closes: https://github.com/Quansight/qhub/issues/638

Tried to do the minimal ammount to support load balancer
configuration. One downside I see with this PR is we are introducing
another 2 configuration variables to the qhub_config.yaml. On the
other hand this has been extremely easy to implment thanks to having
the qhub modules in the same directory.

cc: @leej3 