### PR TITLE
Fix helm upgrade: remove helm_repository data source

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/cluster-autoscaler/main.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/cluster-autoscaler/main.tf
@@ -1,13 +1,8 @@
-data "helm_repository" "autoscaler" {
-  name = "stable"
-  url  = "https://charts.helm.sh/stable"
-}
-
 resource "helm_release" "autoscaler" {
   name      = "cluster-autoscaler"
   namespace = var.namespace
 
-  repository = data.helm_repository.autoscaler.metadata[0].name
+  repository = "https://charts.helm.sh/stable"
   chart      = "stable/cluster-autoscaler"
   version    = "7.1.0"
 


### PR DESCRIPTION
`helm_repository` data source is deprecated now.