### PR TITLE
Remove repo name from chart name: helm_release

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/cluster-autoscaler/main.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/cluster-autoscaler/main.tf
@@ -3,7 +3,7 @@ resource "helm_release" "autoscaler" {
   namespace = var.namespace
 
   repository = "https://charts.helm.sh/stable"
-  chart      = "stable/cluster-autoscaler"
+  chart      = "cluster-autoscaler"
   version    = "7.1.0"
 
   values = concat([


### PR DESCRIPTION
Ref: https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release#argument-reference

This is weird, it should worked without it ideally.