### PR TITLE
Additional config validation checks

### DIFF
--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -141,10 +141,11 @@ class Security(Base):
     users: typing.Dict[str, User]
     groups: typing.Dict[str, Group]
 
-    @validator('users', pre=True)
+    @validator("users", pre=True)
     def validate_uderids(cls, v):
         # raise TypeError if duplicated
         return check_for_duplicates(v)
+
 
 # ================ Providers ===============
 
@@ -250,12 +251,14 @@ class Profiles(Base):
     jupyterlab: typing.List[JupyterLabProfile]
     dask_worker: typing.Dict[str, DaskWorkerProfile]
 
-    @validator('jupyterlab', pre=True)
+    @validator("jupyterlab", pre=True)
     def check_default(cls, v, values):
         """Check if only one default value is present"""
-        default = [attrs['default'] for attrs in v if 'default' in attrs]
+        default = [attrs["default"] for attrs in v if "default" in attrs]
         if default.count(True) > 1:
-            raise TypeError('Multiple default Jupyterlab profiles may cause unexpected problems.')
+            raise TypeError(
+                "Multiple default Jupyterlab profiles may cause unexpected problems."
+            )
         return v
 
 

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -256,7 +256,7 @@ class Profiles(Base):
         default = [attrs['default'] for attrs in v if 'default' in attrs]
         if default.count(True) > 1:
             raise TypeError('Multiple default Jupyterlab profiles may cause unexpected problems.')
-
+        return v
 
 
 # ================ Environment ================

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -1,9 +1,8 @@
 import enum
-from os import pread
 import typing
 
 import pydantic
-from pydantic import validator, ValidationError
+from pydantic import validator
 from qhub.utils import namestr_regex, check_for_duplicates
 
 

--- a/qhub/utils.py
+++ b/qhub/utils.py
@@ -4,6 +4,7 @@ import time
 import os
 import re
 import contextlib
+from typing import Sequence, Set
 
 from .version import __version__
 
@@ -135,3 +136,12 @@ def check_cloud_credentials(config):
         pass
     else:
         raise ValueError("Cloud Provider configuration not supported")
+
+def check_for_duplicates(users: Sequence[dict]) -> Set:
+    uids = set([])
+    for user, attrs in users.items():
+        if attrs['uid'] in uids:
+            raise TypeError(f"Found duplicate uid ({attrs['uid']}) for {user}.")
+        else:
+            uids.add(attrs['uid'])
+    return uids

--- a/qhub/utils.py
+++ b/qhub/utils.py
@@ -144,4 +144,4 @@ def check_for_duplicates(users: Sequence[dict]) -> Set:
             raise TypeError(f"Found duplicate uid ({attrs['uid']}) for {user}.")
         else:
             uids.add(attrs['uid'])
-    return uids
+    return users

--- a/qhub/utils.py
+++ b/qhub/utils.py
@@ -137,11 +137,12 @@ def check_cloud_credentials(config):
     else:
         raise ValueError("Cloud Provider configuration not supported")
 
+
 def check_for_duplicates(users: Sequence[dict]) -> Set:
     uids = set([])
     for user, attrs in users.items():
-        if attrs['uid'] in uids:
+        if attrs["uid"] in uids:
             raise TypeError(f"Found duplicate uid ({attrs['uid']}) for {user}.")
         else:
-            uids.add(attrs['uid'])
+            uids.add(attrs["uid"])
     return users


### PR DESCRIPTION
fix #209 

This PR adds new validators under Pydantic `schema.py`: 
- `check_default` to guarantee that only one instance under Jupyterlab has defined as `default: true`;
- `validate_userids` to guarantee that there is no repeated user id under the users profiles.

The `yaml.safe_load` function inside `qhub render` and [`qhub deploy`](https://github.com/Quansight/qhub/blob/426d327246a5e40a21d8244e2728c917b20386d8/qhub/cli/deploy.py#L55) currently checks the last problem commented in that issue 
> multiple environments with the same name
