### PR TITLE
Include namespace in conda-store PVC

### DIFF
--- a/qhub/render/__init__.py
+++ b/qhub/render/__init__.py
@@ -20,9 +20,10 @@ def patch_dask_gateway_extra_config(config):
     directory.
 
     """
+    namespace = config["namespace"]
     conda_store_volume = {
         "name": "conda-store",
-        "persistentVolumeClaim": {"claimName": "conda-store-dev-share"},
+        "persistentVolumeClaim": {"claimName": f"conda-store-{namespace}-share"},
     }
     extra_pod_config = {"volumes": [conda_store_volume]}
 


### PR DESCRIPTION
This PR builds the name for the conda-store PVC using the `namespace` variable from the config, in the case that the user has changed it from the default value of "dev".

Should resolve #708.

Apologies I don't have any idea how to test this, but submitting in case it's useful.