### PR TITLE
Digital Ocean default general node now s-4vcpu-8gb

### DIFF
--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -111,7 +111,7 @@ DIGITAL_OCEAN = {
     "region": "nyc3",
     "kubernetes_version": "PLACEHOLDER",
     "node_groups": {
-        "general": {"instance": "s-2vcpu-4gb", "min_nodes": 1, "max_nodes": 1},
+        "general": {"instance": "s-4vcpu-8gb", "min_nodes": 1, "max_nodes": 1},
         "user": {"instance": "g-2vcpu-8gb", "min_nodes": 1, "max_nodes": 5},
         "worker": {"instance": "g-2vcpu-8gb", "min_nodes": 1, "max_nodes": 5},
     },


### PR DESCRIPTION
I found my general node (s-2vcpu-4gb) ran out of RAM on Digital Ocean, so replacing with the cheapest 8GB droplet type here.