### PR TITLE
remove secrets from config yaml and terraform configuration files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,13 +76,13 @@ jobs:
         if: ${{ matrix.provider != 'local' }}
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: 0.14.9
+          tf_actions_version: 1.0.0
           tf_actions_subcommand: 'fmt'
           tf_actions_working_dir: 'qhub-${{ matrix.provider }}-deployment/terraform-state'
       - name: 'Terraform Format'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: 0.14.9
+          tf_actions_version: 1.0.0
           tf_actions_subcommand: 'fmt'
           tf_actions_working_dir: 'qhub-${{ matrix.provider }}-deployment/infrastructure'
       - name: QHub Render Artifact

--- a/docs/source/02_get_started/04_configuration.md
+++ b/docs/source/02_get_started/04_configuration.md
@@ -150,7 +150,7 @@ If you wish to avoid storing secrets etc. directly in the config yaml file you
 can instead set the values in environment variables. This substitution is
 triggered by setting config values to "QHUB_SECRET_" followed by the
 environment variable name. For example, you could set the environment variables
-github_client_id and github_client_key and write the following in your config
+"github_client_id" and "github_client_key" and write the following in your config
 file:
 
 ```yaml

--- a/docs/source/02_get_started/04_configuration.md
+++ b/docs/source/02_get_started/04_configuration.md
@@ -144,6 +144,25 @@ security:
       gid: 102
 ```
 
+### Omitting sensitive values
+
+If you wish to avoid storing secrets etc. directly in the config yaml file you
+can instead set the values in environment variables. This substitution is
+triggered by setting config values to "QHUB_SECRET_" followed by the
+environment variable name. For example, you could set the environment variables
+github_client_id and github_client_key and write the following in your config
+file:
+
+```yaml
+security:
+  authentication:
+    type: GitHub
+    config:
+      client_id: QHUB_SECRET_github_client_id
+      client_secret: QHUB_SECRET_github_client_key
+      oauth_callback_url: https://do.qhub.dev/hub/oauth_callback
+```
+
 ### Authentication
 
 `security.authentication` is for configuring the OAuth and GitHub

--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -62,10 +62,7 @@ def guided_install(
     terraform.init(directory="infrastructure")
     terraform.apply(
         directory="infrastructure",
-        targets=[
-            "module.kubernetes",
-            "module.kubernetes-initialization",
-        ],
+        targets=["module.kubernetes", "module.kubernetes-initialization",],
     )
 
     # 04 Create qhub initial state (up to nginx-ingress)
@@ -151,12 +148,9 @@ def check_secrets(config):
         if not var in os.environ:
             missing_env_vars.append(var)
 
-
-
     if missing_env_vars:
         raise EnvironmentError(
             "Some environment variables used to propagate secrets to the "
             "terraform deployment were not set. Please set these before "
             f"continuing: {', '.join(missing_env_vars)}"
         )
-

--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -143,9 +143,9 @@ def check_secrets(config):
     missing_env_vars = []
 
     # Check prefect integration set up.
-    if "prefect" in config:
+    if "prefect" in config and config["prefect"]["enabled"]:
         var = "TF_VAR_prefect_token"
-        if not var in os.environ:
+        if var not in os.environ:
             missing_env_vars.append(var)
 
     if missing_env_vars:

--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -62,7 +62,10 @@ def guided_install(
     terraform.init(directory="infrastructure")
     terraform.apply(
         directory="infrastructure",
-        targets=["module.kubernetes", "module.kubernetes-initialization",],
+        targets=[
+            "module.kubernetes",
+            "module.kubernetes-initialization",
+        ],
     )
 
     # 04 Create qhub initial state (up to nginx-ingress)

--- a/qhub/render/__init__.py
+++ b/qhub/render/__init__.py
@@ -214,41 +214,43 @@ def set_env_vars_in_config(config):
     """
     private_entries = get_secret_config_entries(config)
     for idx in private_entries:
-        set_qhub_secret(config,idx)
+        set_qhub_secret(config, idx)
 
 
-def get_secret_config_entries(config,config_idx=None,private_entries=None):
+def get_secret_config_entries(config, config_idx=None, private_entries=None):
     output = private_entries or []
     if config_idx is None:
         sub_dict = config
         config_idx = []
     else:
-        sub_dict = get_sub_config(config,config_idx)
+        sub_dict = get_sub_config(config, config_idx)
 
     for key, value in sub_dict.items():
         if type(value) is dict:
-            sub_dict_outputs = get_secret_config_entries(config,[*config_idx,key],private_entries)
-            output = [*output,*sub_dict_outputs]
+            sub_dict_outputs = get_secret_config_entries(
+                config, [*config_idx, key], private_entries
+            )
+            output = [*output, *sub_dict_outputs]
         else:
             if "QHUB_SECRET_" in str(value):
-                output = [*output,[*config_idx, key]]
+                output = [*output, [*config_idx, key]]
     return output
 
 
 def get_sub_config(conf, conf_idx):
-    sub_config = functools.reduce(dict.__getitem__,conf_idx,conf)
+    sub_config = functools.reduce(dict.__getitem__, conf_idx, conf)
     return sub_config
 
 
-def set_sub_config(conf, conf_idx,value):
+def set_sub_config(conf, conf_idx, value):
 
-    get_sub_config(conf,conf_idx[:-1])[conf_idx[-1]] = value
+    get_sub_config(conf, conf_idx[:-1])[conf_idx[-1]] = value
 
 
-def set_qhub_secret(config,idx):
-    placeholder = get_sub_config(config,idx)
+def set_qhub_secret(config, idx):
+    placeholder = get_sub_config(config, idx)
     secret_var = get_qhub_secret(placeholder)
-    set_sub_config(config,idx,secret_var)
+    set_sub_config(config, idx, secret_var)
 
 
 def get_qhub_secret(secret_var):
@@ -261,5 +263,3 @@ def get_qhub_secret(secret_var):
             f" '{env_var}' must be set."
         )
     return val
-
-

--- a/qhub/render/__init__.py
+++ b/qhub/render/__init__.py
@@ -1,5 +1,6 @@
 import pathlib
 import collections
+import functools
 import json
 import os
 from shutil import copyfile
@@ -116,6 +117,12 @@ def render_template(output_directory, config_filename, force=False):
 
     with filename.open() as f:
         config = yaml.safe_load(f)
+
+        # For any config values that start with
+        # QHUB_SECRET_, set the values using the
+        # corresponding env var.
+        set_env_vars_in_config(config)
+
         config["repo_directory"] = repo_directory
         patch_dask_gateway_extra_config(config)
 
@@ -191,3 +198,68 @@ def remove_existing_renders(source_repo_dir, dest_repo_dir):
                     os.rmdir(root_path / dir)
                 except OSError:
                     pass  # Silently fail if 'saved' files are present so dir not empty
+
+
+def set_env_vars_in_config(config):
+    """
+
+    For values in the config starting with 'QHUB_SECRET_XXX' the environment
+    variables are searched for the pattern XXX and the config value is
+    modified. This enables setting secret values that should not be directly
+    stored in the config file.
+
+    NOTE: variables are most likely written to a file somewhere upon render. In
+    order to further reduce risk of exposure of any of these variables you might
+    consider preventing storage of the terraform render output.
+    """
+    private_entries = get_secret_config_entries(config)
+    for idx in private_entries:
+        set_qhub_secret(config,idx)
+
+
+def get_secret_config_entries(config,config_idx=None,private_entries=None):
+    output = private_entries or []
+    if config_idx is None:
+        sub_dict = config
+        config_idx = []
+    else:
+        sub_dict = get_sub_config(config,config_idx)
+
+    for key, value in sub_dict.items():
+        if type(value) is dict:
+            sub_dict_outputs = get_secret_config_entries(config,[*config_idx,key],private_entries)
+            output = [*output,*sub_dict_outputs]
+        else:
+            if "QHUB_SECRET_" in str(value):
+                output = [*output,[*config_idx, key]]
+    return output
+
+
+def get_sub_config(conf, conf_idx):
+    sub_config = functools.reduce(dict.__getitem__,conf_idx,conf)
+    return sub_config
+
+
+def set_sub_config(conf, conf_idx,value):
+
+    get_sub_config(conf,conf_idx[:-1])[conf_idx[-1]] = value
+
+
+def set_qhub_secret(config,idx):
+    placeholder = get_sub_config(config,idx)
+    secret_var = get_qhub_secret(placeholder)
+    set_sub_config(config,idx,secret_var)
+
+
+def get_qhub_secret(secret_var):
+    env_var = secret_var.lstrip("QHUB_SECRET_")
+    val = os.environ.get(env_var)
+    if not val:
+        raise EnvironmentError(
+            f"Since '{secret_var}' was found in the"
+            " QHub config, the environment variable"
+            f" '{env_var}' must be set."
+        )
+    return val
+
+

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/prefect/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/prefect/variables.tf
@@ -9,7 +9,7 @@ variable "namespace" {
 }
 
 variable "prefect_token" {
-  type    = string
+  type = string
 }
 
 variable "image" {

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/prefect/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/prefect/variables.tf
@@ -10,7 +10,6 @@ variable "namespace" {
 
 variable "prefect_token" {
   type    = string
-  default = ""
 }
 
 variable "image" {

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,17 +1,17 @@
 import pytest
 from qhub.deploy import check_secrets
 
+
 def test_check_secrets(monkeypatch):
 
     # Should do nothing without prefect key
-    check_secrets({"key":"value"})
+    check_secrets({"key": "value"})
 
     # Should do nothing if appropriate var is set
-    monkeypatch.setenv("TF_VAR_prefect_token","secret_token")
-    check_secrets({"prefect":"value"})
+    monkeypatch.setenv("TF_VAR_prefect_token", "secret_token")
+    check_secrets({"prefect": "value"})
 
     # Should raise error if var is not set
     monkeypatch.delenv("TF_VAR_prefect_token")
     with pytest.raises(EnvironmentError):
-        check_secrets({"prefect":"value"})
-
+        check_secrets({"prefect": "value"})

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -4,14 +4,15 @@ from qhub.deploy import check_secrets
 
 def test_check_secrets(monkeypatch):
 
-    # Should do nothing without prefect key
+    # Should do nothing without prefect key or not enabled
     check_secrets({"key": "value"})
+    check_secrets({"prefect": {"enabled": False}})
 
     # Should do nothing if appropriate var is set
     monkeypatch.setenv("TF_VAR_prefect_token", "secret_token")
-    check_secrets({"prefect": "value"})
+    check_secrets({"prefect": {"enabled": True}})
 
     # Should raise error if var is not set
     monkeypatch.delenv("TF_VAR_prefect_token")
     with pytest.raises(EnvironmentError):
-        check_secrets({"prefect": "value"})
+        check_secrets({"prefect": {"enabled": True}})

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,0 +1,17 @@
+import pytest
+from qhub.deploy import check_secrets
+
+def test_check_secrets(monkeypatch):
+
+    # Should do nothing without prefect key
+    check_secrets({"key":"value"})
+
+    # Should do nothing if appropriate var is set
+    monkeypatch.setenv("TF_VAR_prefect_token","secret_token")
+    check_secrets({"prefect":"value"})
+
+    # Should raise error if var is not set
+    monkeypatch.delenv("TF_VAR_prefect_token")
+    with pytest.raises(EnvironmentError):
+        check_secrets({"prefect":"value"})
+

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -2,7 +2,7 @@ import pytest
 
 from ruamel import yaml
 
-from qhub.render import render_template
+from qhub.render import render_template, set_env_vars_in_config
 from qhub.initialize import render_config
 
 
@@ -37,3 +37,35 @@ def test_render(project, namespace, domain, cloud_provider, ci_provider, auth_pr
 
     output_directory = tmp_path / "test"
     render_template(str(output_directory), config_filename, force=True)
+
+
+def test_get_secret_config_entries(monkeypatch):
+    sec1 = "secret1"
+    sec2 = "nestedsecret1"
+    config_orig = {
+        "key1":"value1",
+        "key2":"QHUB_SECRET_secret_val",
+        "key3":{
+            "nested_key1":"nested_value1",
+            "nested_key2":"QHUB_SECRET_nested_secret_val",
+        },
+    }
+    expected = {
+        "key1":"value1",
+        "key2":sec1,
+        "key3":{
+            "nested_key1":"nested_value1",
+            "nested_key2":sec2,
+        },
+    }
+
+    # should raise error if implied env var is not set
+    with pytest.raises(EnvironmentError):
+        config =  config_orig.copy()
+        set_env_vars_in_config(config)
+
+    monkeypatch.setenv("secret_val", sec1, prepend=False)
+    monkeypatch.setenv("nested_secret_val", sec2, prepend=False)
+    config =  config_orig.copy()
+    set_env_vars_in_config(config)
+    assert config == expected

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -15,7 +15,9 @@ from qhub.initialize import render_config
         ("azure-pytest", "dev", "azure.qhub.dev", "azure", "github-actions", "github"),
     ],
 )
-def test_render(project, namespace, domain, cloud_provider, ci_provider, auth_provider, tmp_path):
+def test_render(
+    project, namespace, domain, cloud_provider, ci_provider, auth_provider, tmp_path
+):
     config = render_config(
         project_name=project,
         namespace=namespace,
@@ -43,29 +45,29 @@ def test_get_secret_config_entries(monkeypatch):
     sec1 = "secret1"
     sec2 = "nestedsecret1"
     config_orig = {
-        "key1":"value1",
-        "key2":"QHUB_SECRET_secret_val",
-        "key3":{
-            "nested_key1":"nested_value1",
-            "nested_key2":"QHUB_SECRET_nested_secret_val",
+        "key1": "value1",
+        "key2": "QHUB_SECRET_secret_val",
+        "key3": {
+            "nested_key1": "nested_value1",
+            "nested_key2": "QHUB_SECRET_nested_secret_val",
         },
     }
     expected = {
-        "key1":"value1",
-        "key2":sec1,
-        "key3":{
-            "nested_key1":"nested_value1",
-            "nested_key2":sec2,
+        "key1": "value1",
+        "key2": sec1,
+        "key3": {
+            "nested_key1": "nested_value1",
+            "nested_key2": sec2,
         },
     }
 
     # should raise error if implied env var is not set
     with pytest.raises(EnvironmentError):
-        config =  config_orig.copy()
+        config = config_orig.copy()
         set_env_vars_in_config(config)
 
     monkeypatch.setenv("secret_val", sec1, prepend=False)
     monkeypatch.setenv("nested_secret_val", sec2, prepend=False)
-    config =  config_orig.copy()
+    config = config_orig.copy()
     set_env_vars_in_config(config)
     assert config == expected


### PR DESCRIPTION
Resolves #13.

Proposal for managing secrets... this approach:

+ Makes use of the fact that terraform variables can be set by setting an environment variable with the same name but prefixed with `TF_VAR_`
+ Could be used for all secrets/tokens.
+ Makes it harder for secrets to leak as they are never stored as plain text.
+ Does not expose secrets during a render (I need to confirm this, I may have to define the variable as sensitive in variables.tf).
+ Can serve as an interim prior to more thorough managment of secrets using something like vault/keycloak.
+ In some cases will require the removal of some values from the schema. e.g. client_id and client_key for google oauth.