### PR TITLE
Add lab extensions jupyter-resource-usage and nbgitpuller

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterlab/environment.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterlab/environment.yaml
@@ -24,6 +24,8 @@ dependencies:
  - ipywidgets >=7.6
  - ipyleaflet >=0.13.5
  - pyviz_comms >=2.0.1
+ - jupyter-resource-usage
+ - nbgitpuller
 
  # cds dashboards
  - cdsdashboards-singleuser >=0.5.7
@@ -47,3 +49,4 @@ dependencies:
  - pip:
    # See install-conda-environment.sh when editing this section.
     - https://github.com/dirkcgrunwald/jupyter_codeserver_proxy-/archive/5596bc9c2fbd566180545fa242c659663755a427.tar.gz
+

--- a/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterlab/environment.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterlab/environment.yaml
@@ -24,7 +24,7 @@ dependencies:
  - ipywidgets >=7.6
  - ipyleaflet >=0.13.5
  - pyviz_comms >=2.0.1
- - jupyter-resource-usage
+ - jupyter-resource-usage >=0.6.0
  - nbgitpuller
 
  # cds dashboards


### PR DESCRIPTION
In our QHub deployment we've found it useful to add a couple of jupyterlab extensions. The first is the `jupyter-resource-usage` extension which shows memory used/available on the VM running lab. The second is the `nbgitpuller` package which allows distributing URLs that load a given notebook into the JupyterHub service. Thought I'd suggest these as generally good additions to include in the lab image.