### PR TITLE
Pin jupyterhub package in lab image to match the hub image

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterlab/environment.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterlab/environment.yaml
@@ -12,7 +12,7 @@ dependencies:
  - jupyterlab >=3
  - jupyter_client
  - jupyter_console
- - jupyterhub
+ - jupyterhub==1.4.1
  - nbconvert
  - nbval
 


### PR DESCRIPTION
The [JupyterHub docs](https://jupyterhub.readthedocs.io/en/stable/admin/upgrading.html?highlight=version#upgrade-jupyterhub-packages) recommend that the version of the jupyterhub package must match between the hub environment and the notebook user environments. 

Currently qhub pins the jupyterhub package to version 1.4.1 in the jupyterhub image environment, but does not pin the jupyterhub package in the jupyterlab environment. This PR suggests pinning also in the jupyterlab environment, to avoid version mismatch between the images. 