### PR TITLE
Update local testing docs

### DIFF
--- a/docs/source/dev_guide/testing.md
+++ b/docs/source/dev_guide/testing.md
@@ -231,7 +231,7 @@ In case you would like to change the generated password (optional), You can use
 script:
 
 ```bash
-python -c "import bcrypt; bcrypt.hashpw(b'<password>', bcrypt.gensalt())"
+python -c "import bcrypt; print(bcrypt.hashpw(b'admin', bcrypt.gensalt()).decode('utf-8'))"
 ```
 Where `<password>` can be changed to any desired value.
 


### PR DESCRIPTION
Currently the code for password generation doesn't print anything to console. Print out value of generated password