### PR TITLE
add prefectLabels and envVars to prefect config

### DIFF
--- a/docs/source/admin_guide/prefect.md
+++ b/docs/source/admin_guide/prefect.md
@@ -16,6 +16,8 @@ prefect:
   image: prefecthq/prefect:0.14.22-python3.8
 ```
 
+TODO: add docs for `prefectLabels` and `envVars`.
+
 There are a bunch of components in getting Prefect working for you, here
 is a brief description of them:
 

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -73,9 +73,15 @@ class ClearML(Base):
 # ============== Prefect =============
 
 
+class PrefectAgent(Base):
+  prefectLabels: typing.Optional[typing.List[str]]
+  envVars: typing.Optional[typing.Dict[str, str]]
+
+
 class Prefect(Base):
     enabled: bool
     image: typing.Optional[str]
+    agent: typing.Optional[PrefectAgent]
 
 
 # ============= Terraform ===============

--- a/qhub/template/cookiecutter.json
+++ b/qhub/template/cookiecutter.json
@@ -21,7 +21,11 @@
     },
     "prefect": {
         "enabled": null,
-        "image": null
+        "image": null,
+        "agent": {
+            "prefectLabels": [],
+            "envVars": {}
+        }
     },
     "security": null,
     "default_images": null,

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
@@ -235,6 +235,12 @@ module "prefect" {
   {% if cookiecutter.prefect.image is defined -%}
   image                = "{{ cookiecutter.prefect.image }}"
   {% endif -%}
+  {% if cookiecutter.prefect.agent.prefectLabels is defined -%}
+  image                = "{{ cookiecutter.prefect.agent.prefectLabels }}"
+  {% endif -%}
+  {% if cookiecutter.prefect.agent.envVars is defined -%}
+  image                = "{{ cookiecutter.prefect.agent.envVars }}"
+  {% endif -%}
 }
 {% endif -%}
 

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
@@ -236,7 +236,7 @@ module "prefect" {
   image                = "{{ cookiecutter.prefect.image }}"
   {% endif -%}
   {% if cookiecutter.prefect.agent.prefectLabels is defined -%}
-  image                = "{{ cookiecutter.prefect.agent.prefectLabels }}"
+  prefectLabels        = "{{ cookiecutter.prefect.agent.prefectLabels }}"
   {% endif -%}
   {% if cookiecutter.prefect.agent.envVars is defined -%}
   image                = "{{ cookiecutter.prefect.agent.envVars }}"

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/prefect/chart/templates/prefect.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/prefect/chart/templates/prefect.yaml
@@ -40,7 +40,7 @@ spec:
             - name: IMAGE_PULL_SECRETS
               value: ''
             - name: PREFECT__CLOUD__AGENT__LABELS
-              value: '[]'
+              value: {{ .Values.agent.prefectLabels | toJson | quote }}
             - name: JOB_MEM_REQUEST
               value: ''
             - name: JOB_MEM_LIMIT
@@ -57,6 +57,8 @@ spec:
               value: cloud
             - name: PREFECT__CLOUD__AGENT__AGENT_ADDRESS
               value: http://:8080
+            - name: PREFECT__CLOUD__AGENT__ENV_VARS
+              value: {{ .Values.agent.envVars | toJson | quote }}
           image: {{ .Values.prefectImage }}
           imagePullPolicy: Always
           livenessProbe:

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/prefect/chart/values.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/prefect/chart/values.yaml
@@ -3,3 +3,6 @@ namespace: <placeholder>
 serviceAccount: prefect
 prefectToken: "<placeholder>"
 cloudApi: "<placeholder>"
+agent:
+  prefectLabels: []
+  envVars: {}

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/prefect/main.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/prefect/main.tf
@@ -27,4 +27,14 @@ resource "helm_release" "prefect" {
     name  = "cloudApi"
     value = var.cloud_api
   }
+
+  set {
+    name  = "agent.prefectLabels"
+    value = var.agent.prefectLabels
+  }
+
+  set {
+    name  = "agent.evnVars"
+    value = var.agent.evnVars
+  }
 }

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/prefect/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/prefect/variables.tf
@@ -21,3 +21,13 @@ variable "cloud_api" {
   type    = string
   default = "https://api.prefect.io"
 }
+
+variable "agent.prefectLabels" {
+  type    = list
+  default = []
+}
+
+variable "agent.prefectLabels" {
+  type    = map
+  default = {}
+}


### PR DESCRIPTION
This is a quick attempt at adding labels and environment variables to the prefect agent chart. This is my first time touching qhub and terraform so I'm very open to suggestions on better ways to go about this.

If you are starting a review, I'd start at `.../services/prefect/chart/templates/prefect.yaml` and work backwards from there.

This initial implementation would expose two new parameters under `prefect` like this:

```yaml
prefect:
  enabled: true
  agent:
    prefectLabels: ['foo', 'bar']
    envVars: {'TZ': 'UTC'}
```

closes #764 