### PR TITLE
Update `remove_existing_renders` to only delete qhub related files/directories

### DIFF
--- a/qhub/render/__init__.py
+++ b/qhub/render/__init__.py
@@ -3,7 +3,7 @@ import collections
 import functools
 import json
 import os
-from shutil import copyfile
+from shutil import copyfile, rmtree
 from gitignore_parser import parse_gitignore
 
 from ruamel import yaml
@@ -133,7 +133,7 @@ def render_template(output_directory, config_filename, force=False):
 
     remove_existing_renders(
         dest_repo_dir=output_directory / repo_directory,
-        verbosity=0,
+        verbosity=2,
     )
 
     generate_files(
@@ -152,27 +152,24 @@ def remove_existing_renders(dest_repo_dir, verbosity=0):
     """
     home_dir = pathlib.Path.home()
     if pathlib.Path.cwd() == home_dir:
-        raise ValueError(f"Deploying QHub from the home directory, {home_dir}, is not permitted.")
+        raise ValueError(
+            f"Deploying QHub from the home directory, {home_dir}, is not permitted."
+        )
 
-    deletable_dirs = ["terraform-state", ".github", "infrastructure", "image"]
+    deletable_dirs = [
+        "terraform-state",
+        ".github",
+        "infrastructure",
+        "image",
+        ".gitlab-ci.yml",
+    ]
 
     for deletable_dir in deletable_dirs:
         deletable_dir = dest_repo_dir / deletable_dir
         if deletable_dir.exists():
             if verbosity > 0:
                 print(f"Deleting all files and directories beneath {deletable_dir} ...")
-            for root, dirs, files in os.walk(deletable_dir, topdown=False):
-                for f in files:
-                    fp = pathlib.Path(root) / fp
-                    if verbosity > 1:
-                        print(f"... deleting: {fp}")
-                    fp.unlink(missing_ok=True)
-                for d in dirs:
-                    dp = pathlib.Path(root) / dp
-                    if verbosity > 1:
-                        print(f"... deleting: {dp}")
-                    dp.rmdir()
-
+            rmtree(deletable_dir)
 
 
 def set_env_vars_in_config(config):

--- a/qhub/render/__init__.py
+++ b/qhub/render/__init__.py
@@ -3,8 +3,7 @@ import collections
 import functools
 import json
 import os
-from shutil import copyfile, rmtree
-from gitignore_parser import parse_gitignore
+from shutil import rmtree
 
 from ruamel import yaml
 from cookiecutter.generate import generate_files

--- a/qhub/render/__init__.py
+++ b/qhub/render/__init__.py
@@ -156,11 +156,9 @@ def remove_existing_renders(source_repo_dir, dest_repo_dir):
 
     Inputs must be pathlib.Path
     """
-    home = pathlib.Path.home()
-    if pathlib.Path.cwd() == pathlib.Path.home():
-        raise ValueError(f"Deploying from user's home directory, {str(home)}, is not permitted.")
-
-    deletable_dirs = ["terraform-state", ".github", "infrastructure", "images"]
+    home_dir = pathlib.Path.home()
+    if pathlib.Path.cwd() == home_dir:
+        raise ValueError(f"Deploying from user's home directory, {home_dir}, is not permitted.")
 
     copyfile(str(source_repo_dir / ".gitignore"), str(dest_repo_dir / ".gitignore"))
 
@@ -173,9 +171,11 @@ def remove_existing_renders(source_repo_dir, dest_repo_dir):
         def qhubignore_matches(_):
             return False  # Dummy blank qhubignore
 
+    deletable_dirs = ["terraform-state", ".github", "infrastructure", "images"]
+
     for deletable_dir in deletable_dirs:
         deletable_dir = dest_repo_dir / deletable_dir
-        print(f"Deleting all files and directories in {deletable_dir}...")
+        print(f"Deleting all files and directories beneath {deletable_dir} ...")
         for root, dirs, files in os.walk(deletable_dir, topdown=False):
             for f in files:
                 p = pathlib.Path(root) / f
@@ -184,36 +184,6 @@ def remove_existing_renders(source_repo_dir, dest_repo_dir):
                 p = pathlib.Path(root) / d
                 p.rmdir()
 
-            # if (
-            #     root.startswith(f"{str(dest_repo_dir)}/.git_test/")
-            #     or root == f"{str(dest_repo_dir)}/.git_test"
-            # ):
-            #     # Leave everything in the .git folder
-            #     continue
-
-            # root_path = pathlib.Path(root)
-
-            # if root != str(
-            #     dest_repo_dir
-            # ):  # Do not delete top-level files such as qhub-config.yaml!
-            #     for file in files:
-
-            #         if not gitignore_matches(root_path / file) and not qhubignore_matches(
-            #             root_path / file
-            #         ):
-
-            #             os.remove(root_path / file)
-
-            # for dir in dirs:
-            #     if (
-            #         not gitignore_matches(root_path / dir)
-            #         and not (dir == ".git" and root_path == dest_repo_dir)
-            #         and not qhubignore_matches(root_path / dir)
-            #     ):
-            #         try:
-            #             os.rmdir(root_path / dir)
-            #         except OSError:
-            #             pass  # Silently fail if 'saved' files are present so dir not empty
 
 
 def set_env_vars_in_config(config):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,23 +1,42 @@
 import pytest
 
-from ruamel import yaml
+from ruamel.yaml import YAML
 
-from qhub.render import render_template, set_env_vars_in_config
+from qhub.render import render_template, set_env_vars_in_config, remove_existing_renders
 from qhub.initialize import render_config
 
+INIT_INPUTS = [
+    # project, namespace, domain, cloud_provider, ci_provider, auth_provider
+    ("do-pytest", "dev", "do.qhub.dev", "do", "github-actions", "github"),
+    ("aws-pytest", "dev", "aws.qhub.dev", "aws", "github-actions", "github"),
+    ("gcp-pytest", "dev", "gcp.qhub.dev", "gcp", "github-actions", "github"),
+    ("azure-pytest", "dev", "azure.qhub.dev", "azure", "github-actions", "github"),
+]
+QHUB_CONFIG_FN = "qhub-config.yaml"
+PRESERVED_DIR = "preserved_dir"
 
-@pytest.mark.parametrize(
-    "project, namespace, domain, cloud_provider, ci_provider, auth_provider",
-    [
-        ("do-pytest", "dev", "do.qhub.dev", "do", "github-actions", "github"),
-        ("aws-pytest", "dev", "aws.qhub.dev", "aws", "github-actions", "github"),
-        ("gcp-pytest", "dev", "gcp.qhub.dev", "gcp", "github-actions", "github"),
-        ("azure-pytest", "dev", "azure.qhub.dev", "azure", "github-actions", "github"),
-    ],
-)
-def test_render(
-    project, namespace, domain, cloud_provider, ci_provider, auth_provider, tmp_path
-):
+
+@pytest.fixture
+def init_render(request, tmp_path):
+    (
+        project,
+        namespace,
+        domain,
+        cloud_provider,
+        ci_provider,
+        auth_provider,
+    ) = request.param
+
+    output_directory = tmp_path / f"{cloud_provider}_output_dir"
+    output_directory.mkdir()
+    qhub_config = output_directory / QHUB_CONFIG_FN
+
+    # data that should NOT be deleted when `qhub render` is called
+    preserved_directory = output_directory / PRESERVED_DIR
+    preserved_directory.mkdir()
+    preserved_filename = preserved_directory / "file.txt"
+    preserved_filename.write_text("This is a test...")
+
     config = render_config(
         project_name=project,
         namespace=namespace,
@@ -32,13 +51,12 @@ def test_render(
         kubernetes_version="1.18.0",
         disable_prompt=True,
     )
+    yaml = YAML(typ="unsafe", pure=True)
+    yaml.dump(config, qhub_config)
 
-    config_filename = tmp_path / (project + ".yaml")
-    with open(config_filename, "w") as f:
-        yaml.dump(config, f)
+    render_template(str(output_directory), qhub_config, force=True)
 
-    output_directory = tmp_path / "test"
-    render_template(str(output_directory), config_filename, force=True)
+    yield (output_directory, request)
 
 
 def test_get_secret_config_entries(monkeypatch):
@@ -71,3 +89,50 @@ def test_get_secret_config_entries(monkeypatch):
     config = config_orig.copy()
     set_env_vars_in_config(config)
     assert config == expected
+
+
+@pytest.mark.parametrize(
+    "init_render",
+    INIT_INPUTS,
+    indirect=True,
+)
+def test_render_template(init_render):
+    output_directory, request = init_render
+    (
+        project,
+        namespace,
+        domain,
+        cloud_provider,
+        ci_provider,
+        auth_provider,
+    ) = request.param
+    qhub_config = output_directory / QHUB_CONFIG_FN
+
+    yaml = YAML()
+    qhub_config_json = yaml.load(qhub_config.read_text())
+
+    assert qhub_config_json["project_name"] == project
+    assert qhub_config_json["namespace"] == namespace
+    assert qhub_config_json["domain"] == domain
+    assert qhub_config_json["provider"] == cloud_provider
+
+
+@pytest.mark.parametrize(
+    "init_render",
+    INIT_INPUTS,
+    indirect=True,
+)
+def test_remove_existing_renders(init_render):
+    output_directory, request = init_render
+    dirs = [_.name for _ in output_directory.iterdir()]
+    preserved_files = [_ for _ in (output_directory / PRESERVED_DIR).iterdir()]
+
+    # test `remove_existing_renders` implicitly
+    assert PRESERVED_DIR in dirs
+    assert len(preserved_files[0].read_text()) > 0
+
+    # test `remove_existing_renders` explicitly
+    remove_existing_renders(output_directory)
+
+    assert PRESERVED_DIR in dirs
+    assert len(preserved_files[0].read_text()) > 0


### PR DESCRIPTION
Closes #767 

The approach taken will only remove files/directories found in the `deletable_dirs` list. In the linked issue, the acceptance criteria specifies removing all `os.remove` and `shutil.rmtree` logic so my current solution employs `Path` object methods (which essentially do the same thing). 

I have also added a `verbosity` flag (currently set to `0` - none) if and when we would like to output the list of files/directories being deleted. 

All feedback is welcome :)