### PR TITLE
Spin up dask-gateway via Cypress

### DIFF
--- a/tests_e2e/cypress/notebooks/BasicTest.ipynb
+++ b/tests_e2e/cypress/notebooks/BasicTest.ipynb
@@ -15,7 +15,13 @@
     }
    ],
    "source": [
-    "print('test')"
+    "print('test')\n",
+    "\n",
+    "from dask_gateway import Gateway\n",
+    "gateway = Gateway()\n",
+    "options = gateway.cluster_options()\n",
+    "cluster = gateway.new_cluster(options)\n",
+    "cluster"
    ]
   },
   {


### PR DESCRIPTION
What will be nice here is running a python script when the dask gateway is up and running a couple of tests to check that Dask Gateway is reachable.