### PR TITLE
Make ForwardAuth optional for ClearML

### DIFF
--- a/docs/source/admin_guide/clearml.md
+++ b/docs/source/admin_guide/clearml.md
@@ -44,3 +44,17 @@ google_cloud_platform:
 ## Accessing the ClearML server
 
 The ClearML server can be accessed at: `app.clearml.your-qhub-domain.com`
+
+## Authentication
+
+The ClearML dashboard is secured by default with JupyterHub OAuth
+via Traefik ForwardAuth. You can disable it via a flag in the QHub
+config yaml:
+
+```yaml
+clearml:
+  enabled: true
+  enable_forward_auth: false
+```
+
+This is especially useful for accessing ClearML programmatically.

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -68,6 +68,7 @@ class Monitoring(Base):
 
 class ClearML(Base):
     enabled: bool
+    enable_forward_auth: typing.Optional[bool]
 
 
 # ============== Prefect =============

--- a/qhub/template/cookiecutter.json
+++ b/qhub/template/cookiecutter.json
@@ -17,7 +17,8 @@
         "enabled": null
     },
     "clearml": {
-        "enabled": null
+        "enabled": null,
+        "enable_forward_auth": null
     },
     "prefect": {
         "enabled": null,

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
@@ -257,6 +257,9 @@ module "clearml" {
   namespace    = var.environment
   external-url = var.endpoint
   tls          = module.qhub.tls
+{% if cookiecutter.clearml.enable_forward_auth is defined -%}
+  enable-forward-auth = {{ cookiecutter.clearml.enable_forward_auth | default(false,true) | jsonify }}
+{% endif -%}
   depends_on = [
     module.qhub
   ]

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/clearml/ingress.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/clearml/ingress.tf
@@ -8,12 +8,12 @@ locals {
   clearml_apiserver            = "${local.clearml-prefix}-apiserver"
 
   forward_auth_middleware = "traefik-forward-auth"
-  clearml_middleware = [
+  clearml_middleware = var.enable-forward-auth ? [
     {
       name      = local.forward_auth_middleware
       namespace = var.namespace
     }
-  ]
+  ] : []
 }
 
 resource "kubernetes_manifest" "clearml-app" {

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/clearml/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/clearml/variables.tf
@@ -25,3 +25,8 @@ variable "external-url" {
 variable "tls" {
   description = "TLS configuration"
 }
+
+variable "enable-forward-auth" {
+  type    = bool
+  default = true
+}


### PR DESCRIPTION
This makes ForwardAuth optional for ClearML.