### PR TITLE
Increase default subnets in AWS VPC

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/aws/network/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/aws/network/variables.tf
@@ -35,6 +35,7 @@ variable "aws_availability_zones" {
 variable "vpc_cidr_block" {
   description = "VPC cidr for subnets to be inside of"
   type        = string
+  default     = "10.0.0.0/8"
 }
 
 variable "vpc_cidr_newbits" {


### PR DESCRIPTION
Closes #828 

This will enable AWS subnets to handle `2**(32-8-4) = 1048576` IP addresses.