### PR TITLE
Pydantic validation for auth

### DIFF
--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -1,5 +1,6 @@
 import enum
 import typing
+from abc import ABC
 
 import pydantic
 from pydantic import validator, root_validator
@@ -135,12 +136,58 @@ class Auth0Config(Base):
     auth0_subdomain: str
 
 
-class Authentication(Base):
+class Authentication(Base, ABC):
+    _types: typing.Dict[str, type] = {}
+
     type: AuthenticationEnum
-    authentication_class: typing.Optional[str]
-    config: typing.Optional[
-        typing.Union[Auth0Config, GitHubConfig, typing.Dict[str, typing.Any]]
-    ]
+
+    # Based on https://github.com/samuelcolvin/pydantic/issues/2177#issuecomment-739578307
+
+    # This allows type field to determine which subclass of Authentication should be used for validation.
+
+    # Used to register automatically all the submodels in `_types`.
+    def __init_subclass__(cls):
+        cls._types[cls._typ.value] = cls
+
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value: typing.Dict[str, typing.Any]) -> "Authentication":
+        if "type" not in value:
+            raise ValueError("type field is missing from security.authentication")
+
+        specified_type = value.get("type")
+        sub_class = cls._types.get(specified_type, None)
+
+        if not sub_class:
+            raise ValueError(
+                f"No registered Authentication type called {specified_type}"
+            )
+
+        # init with right submodel
+        return sub_class(**value)
+
+
+class PasswordAuthentication(Authentication):
+    _typ = AuthenticationEnum.password
+
+
+class Auth0Authentication(Authentication):
+    _typ = AuthenticationEnum.auth0
+    config: Auth0Config
+
+
+class GitHubAuthentication(Authentication):
+    _typ = AuthenticationEnum.github
+    config: GitHubConfig
+
+
+class CustomAuthentication(Authentication):
+    _typ = AuthenticationEnum.custom
+    authentication_class: str
+    config: typing.Dict[str, typing.Any]
 
 
 # =========== Users and Groups =============


### PR DESCRIPTION
There are four different types of Authentication object that can appear in the qhub-config.yaml, all with slightly different formats.

The previous schema code allowed all variations through - but failed to stop Pydantic allowing some invalid forms through.

Below are three examples of YAML that might be expected.

For GitHub:

```
security:
  authentication:
    type: GitHub
    config:
      client_id: githubclient
      client_secret: githubsecret
      oauth_callback_url: https://qhubtest.com/hub/oauth_callback
```

For plain passwords - note there is no `config` section at all:

```
security:
  authentication:
    type: password
```

For custom authenticators - note there is an extra `authentication_class` field required, and `config` has extra fields compared to that for GitHub above (in fact, for custom we allow any key/value pairs):

```
security:
  authentication:
    type: custom
    authentication_class: "oauthenticator.google.GoogleOAuthenticator"
    config:
      login_service: "My Login Button"
      oauth_callback_url: 'https://qhubtest.com/hub/oauth_callback'
      client_id: 'your-client-id'
      client_secret: 'your-client-secret'
```

Previously, the Pydantic model for Authentication looked something like this:

```
class Authentication(Base):
    type: AuthenticationEnum
    authentication_class: typing.Optional[str]
    config: typing.Optional[
        typing.Union[Auth0Config, GitHubConfig, typing.Dict[str, typing.Any]]
    ]
```

The problem with this is that it allows cross-pollution of the various schema. It has to make `authentication_class` optional because it is required for custom type but actually should be omitted for the other types. Likewise, `config` has to be optional because it should not appear for password type but should be present and set to one of the listed types (Auth0Config etc) in the other cases. And let's say you misspell one of the Auth0Config fields, it is still allowed because the generic Dict type is available in the Union to cover the custom auth case, whereas we would like Pydantic to catch it as a missing/extra field when the `type` is Auth0.

So Pydantic allows Yaml like the following, and we would have to sense-check it elsewhere in the code:

```
security:
  authentication:
    type: GitHub
    authentication_class: "field.should.not.be.here"
    config:
      login_service: "Not Supposed To Be Here"
      oauth_callback_url: 'https://qhubtest.com/hub/oauth_callback'
      client_id: 'your-client-id'
#      client_secret: 'your-client-secret' - omitted but is really required
```

The solution uses class inheritance and picks a validator from the appropriate subclass based on the `type` field's value.

The `Security` class still starts like this specifying the Authentication base class:
```
class Security(Base):
    authentication: Authentication
    ...
```