### PR TITLE
Add minimal support `centos` images

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -25,8 +25,10 @@ jobs:
       matrix:
         dockerfile:
           - jupyterlab
+          - jupyterlab-centos
           - jupyterhub
           - dask-worker
+          - dask-worker-centos
           - dask-gateway
           - conda-store
     steps:

--- a/docs/source/user_guide/experimental.md
+++ b/docs/source/user_guide/experimental.md
@@ -1,9 +1,9 @@
-# Experimental Features
+# Experimental features
 
-> NOTE: The features listed below are experimental and should be used with caution.
+> NOTE: The features listed below are experimental, proceed with caution.
 
 
-## CentOS `jupyterlab` and `dask-worker` Profiles
+## CentOS `jupyterlab` and `dask-worker` profiles
 
 The default images used during a typical QHub deployment are running on `ubuntu`. If you need your `jupyterlab` or `dask-worker` pods to run on `centOS` instead, simply update the appropriate images in your `qhub-config.yaml`.
 

--- a/docs/source/user_guide/experimental.md
+++ b/docs/source/user_guide/experimental.md
@@ -1,0 +1,40 @@
+# Experimental Features
+
+> NOTE: The features listed below are experimental and should be used with caution.
+
+
+## CentOS `jupyterlab` and `dask-worker` Profiles
+
+The default images used during a typical QHub deployment are running on `ubuntu`. If you need your `jupyterlab` or `dask-worker` pods to run on `centOS` instead, simply update the appropriate images in your `qhub-config.yaml`.
+
+```
+...
+default_images:
+  jupyterhub: quansight/qhub-jupyterhub:main
+  jupyterlab: quansight/qhub-jupyterlab-centos:main     <--- here
+  dask_worker: quansight/qhub-dask-worker-centos:main   <--- here
+  dask_gateway: quansight/qhub-dask-gateway:main
+  conda_store: quansight/qhub-conda-store:main
+...
+profiles:
+  jupyterlab:
+  - display_name: Small Instance
+    description: Stable environment with 1 cpu / 4 GB ram
+    default: true
+    kubespawner_override:
+      cpu_limit: 0.25
+      cpu_guarantee: 0.25
+      mem_limit: 2G
+      mem_guarantee: 2G
+      image: quansight/qhub-jupyterlab-centos:main      <--- here
+  dask_worker:
+    Small Worker:
+      worker_cores_limit: 0.5
+      worker_cores: 0.5
+      worker_memory_limit: 2G
+      worker_memory: 2G
+      worker_threads: 1
+      image: quansight/qhub-dask-worker-centos:main     <--- here
+```
+
+Then to get these changes to take hold, simply redeploy QHub.

--- a/qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.dask-worker-centos
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.dask-worker-centos
@@ -1,0 +1,36 @@
+FROM centos:centos8.4.2105
+LABEL org.opencontainers.image.source="https://github.com/Quansight/qhub"
+
+COPY scripts/* /opt/scripts/
+RUN /opt/scripts/install-yum-minimal.sh
+
+# COPY scripts/fix-permissions /opt/scripts/fix-permissions
+
+# These can but should not be changed. ids will be arbitrary at run time.
+ARG NB_USER=jovyan
+ARG NB_UID=1000
+ARG NB_GID=100
+
+ENV CONDA_VERSION py37_4.10.3
+ENV CONDA_SHA256 a1a7285dea0edc430b2bc7951d89bb30a2a1b32026d2a7b02aacaaa95cf69c7c
+SHELL ["/bin/bash", "-c"]
+
+ENV PATH=/opt/conda/bin:${PATH}:/opt/scripts
+
+# ============== base install ===============
+# COPY scripts/install-conda.sh /opt/scripts/install-conda.sh
+
+RUN /opt/scripts/install-conda.sh
+
+# ========== dask-worker install ===========
+COPY dask-worker/* /opt/dask-worker/
+# COPY scripts/install-conda-environment.sh /opt/scripts/install-conda-environment.sh
+RUN /opt/scripts/install-conda-environment.sh /opt/dask-worker/environment.yaml 'false'
+
+# ========== Setup GPU Paths ============
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64
+ENV NVIDIA_PATH=/usr/local/nvidia/bin
+ENV PATH="$NVIDIA_PATH:$PATH"
+
+# COPY dask-worker /opt/dask-worker
+RUN /opt/dask-worker/postBuild

--- a/qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.dask-worker-centos
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.dask-worker-centos
@@ -4,8 +4,6 @@ LABEL org.opencontainers.image.source="https://github.com/Quansight/qhub"
 COPY scripts/* /opt/scripts/
 RUN /opt/scripts/install-yum-minimal.sh
 
-# COPY scripts/fix-permissions /opt/scripts/fix-permissions
-
 # These can but should not be changed. ids will be arbitrary at run time.
 ARG NB_USER=jovyan
 ARG NB_UID=1000
@@ -18,13 +16,10 @@ SHELL ["/bin/bash", "-c"]
 ENV PATH=/opt/conda/bin:${PATH}:/opt/scripts
 
 # ============== base install ===============
-# COPY scripts/install-conda.sh /opt/scripts/install-conda.sh
-
 RUN /opt/scripts/install-conda.sh
 
 # ========== dask-worker install ===========
 COPY dask-worker/* /opt/dask-worker/
-# COPY scripts/install-conda-environment.sh /opt/scripts/install-conda-environment.sh
 RUN /opt/scripts/install-conda-environment.sh /opt/dask-worker/environment.yaml 'false'
 
 # ========== Setup GPU Paths ============
@@ -32,5 +27,4 @@ ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64
 ENV NVIDIA_PATH=/usr/local/nvidia/bin
 ENV PATH="$NVIDIA_PATH:$PATH"
 
-# COPY dask-worker /opt/dask-worker
 RUN /opt/dask-worker/postBuild

--- a/qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.jupyterlab-centos
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.jupyterlab-centos
@@ -1,0 +1,81 @@
+FROM centos:centos8.4.2105
+LABEL org.opencontainers.image.source="https://github.com/Quansight/qhub"
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+RUN chmod -R a-w ~
+
+COPY scripts/* /opt/scripts/
+
+RUN /opt/scripts/install-yum-minimal.sh
+
+# These can but should not be changed. ids will be arbitrary at run time.
+ARG NB_USER=jovyan
+ARG NB_UID=1000
+ARG NB_GID=100
+
+ENV CONDA_VERSION py37_4.10.3
+ENV CONDA_SHA256 a1a7285dea0edc430b2bc7951d89bb30a2a1b32026d2a7b02aacaaa95cf69c7c
+SHELL ["/bin/bash", "-c"]
+ENV CONDA_DIR=/opt/conda \
+    DEFAULT_ENV=default
+
+# Set timezone
+ENV TZ=America/Chicago
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Set PATH for Dockerfile so that conda works and some useful scripts are
+# available. Any changes intended to propagate to runtime containers should be
+# set in /etc/profile.d (see setup_shell_behavior.sh)
+ENV PATH=/opt/conda/envs/${DEFAULT_ENV}/bin:/opt/conda/bin:${PATH}:/opt/scripts
+
+# ============= base install ===============
+# install conda
+RUN echo "$SHELL"; env; cat ~/.bashrc; cat ~/.profile ; /opt/scripts/install-conda.sh
+
+# ========== jupyterlab install ============
+COPY jupyterlab/* /opt/jupyterlab/
+RUN /opt/scripts/install-yum.sh /opt/jupyterlab/yum.txt
+
+ARG SKIP_CONDA_SOLVE=no
+COPY jupyterlab/* /opt/jupyterlab/
+RUN \
+    if [ "${SKIP_CONDA_SOLVE}" != "no" ];then  \
+        ENV_FILE=/opt/jupyterlab/conda-linux-64.lock ; \
+    else  \
+        ENV_FILE=/opt/jupyterlab/environment.yaml ; \
+    fi ; \
+    /opt/scripts/install-conda-environment.sh "${ENV_FILE}" 'true' && \
+    /opt/jupyterlab/postBuild
+
+# ========== Setup GPU Paths ============
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64
+ENV NVIDIA_PATH=/usr/local/nvidia/bin
+ENV PATH="$NVIDIA_PATH:$PATH"
+
+# ========== users configuration ============
+# Establish some default shell behaviors for all users. This writes to /etc so
+# that the shell setup will always be used by users
+RUN setup_shell_behavior.sh ${DEFAULT_ENV} \
+    && fix-permissions /etc
+
+# ========== change user though this will change upon deployment...  ============
+# Create user & group jovyan, this is only relevant for
+# local testing where the user has not mounted their
+# own home directory to the container. During
+# deployment this is mounted over and so an equivalent
+# should be executed upon user initialization.
+RUN groupadd --gid ${NB_UID} ${NB_USER} && \
+    useradd \
+    --comment 'Jupyter container user' \
+    --create-home \
+    --no-log-init \
+    --shell /bin/bash \
+    --gid ${NB_UID} \
+    --uid ${NB_UID} \
+    ${NB_USER}
+
+# Have jovyan user own /home/jovyan/.local for local testing.
+RUN chown jovyan /home/jovyan
+
+USER ${NB_UID}
+WORKDIR /home/${NB_USER}

--- a/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterlab/yum.txt
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterlab/yum.txt
@@ -1,0 +1,28 @@
+# assign uid/gid names
+nss_wrapper
+
+# utilities
+wget
+curl
+
+# development utilities
+git
+openssh-clients
+
+# editors
+nano
+vim
+emacs
+
+# conda prerequisites for GUI packages
+# See https://docs.anaconda.com/anaconda/install/linux/
+libXcomposite
+libXcursor
+libXi
+libXtst
+libXrandr
+alsa-lib
+mesa-libEGL
+libXdamage
+mesa-libGL
+libXScrnSaver

--- a/qhub/template/{{ cookiecutter.repo_directory }}/image/scripts/install-yum-minimal.sh
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/image/scripts/install-yum-minimal.sh
@@ -1,0 +1,4 @@
+yum -y update && \
+    yum install -y wget bzip2 ca-certificates curl git && \
+    yum clean all && \
+    rm -rf /var/cache/yum /var/tmp/* /tmp/*

--- a/qhub/template/{{ cookiecutter.repo_directory }}/image/scripts/install-yum.sh
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/image/scripts/install-yum.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -xe
+
+# Assumes apt packages installs packages in "$1" argument
+
+# ====== install apt packages ========
+yum update -y
+yum install -y $(grep -vE "^\s*#" $1  | tr "\n" " ")
+
+# ========== cleanup apt =============
+yum clean all
+rm -rf /tmp/* /var/tmp/* /var/cache/yum


### PR DESCRIPTION
Fixes | Closes | Resolves #884 

> Please remove anything marked as optional that you don't need to fill in. Choose one of the keywords preceding to refer to the issue this PR solves, followed by the issue number (e.g Fixes # 666). If there is no issue, remove the line. Remove this note after reading.

## Changes:

- Add two new images, increase the number of images qhub maintains to seven.
  - `qhub-jupyterlab-centos`
  - `qhub-dask-worker-centos` 
- Update `image.yaml` to ensure these two new images also get built.

This PR does not change any of the `ubuntu` images or how they are built and this PR is takes another chunk out of the large PR #904. 

I have added docs to illustrate how to swap out `ubuntu`-based images with `centos`-based images. 

There is more work that can be done to simplify the dockerfiles in general. That said, this will allow people to start using these `centos` as soon as possible.  cc @kcpevey @dharhas 

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [x] Yes
- [ ] No

I successfully tested launching `qhub-jupyterlab-centos` on a minikube deployment.


### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered and more.