### PR TITLE
qhub upgrade custom auth plus tests

### DIFF
--- a/qhub/cli/upgrade.py
+++ b/qhub/cli/upgrade.py
@@ -8,6 +8,11 @@ logger = logging.getLogger(__name__)
 def create_upgrade_subcommand(subparser):
     subparser = subparser.add_parser("upgrade")
     subparser.add_argument("-c", "--config", help="qhub configuration", required=True)
+    subparser.add_argument(
+        "--attempt-fixes",
+        action="store_true",
+        help="Attempt to fix the config for any incompatibilities between your old and new QHub versions.",
+    )
     subparser.set_defaults(func=handle_upgrade)
 
 
@@ -18,4 +23,4 @@ def handle_upgrade(args):
             f"passed in configuration filename={config_filename} must exist"
         )
 
-    do_upgrade(config_filename)
+    do_upgrade(config_filename, args.attempt_fixes)

--- a/qhub/upgrade.py
+++ b/qhub/upgrade.py
@@ -17,7 +17,7 @@ from .version import __version__
 logger = logging.getLogger(__name__)
 
 
-def do_upgrade(config_filename):
+def do_upgrade(config_filename, attempt_fixes=False):
 
     config = load_yaml(config_filename)
 
@@ -37,7 +37,9 @@ def do_upgrade(config_filename):
 
     start_version = config.get("qhub_version", "")
 
-    UpgradeStep.upgrade(config, start_version, __version__, config_filename)
+    UpgradeStep.upgrade(
+        config, start_version, __version__, config_filename, attempt_fixes
+    )
 
     # Backup old file
     backup_config_file(config_filename, f".{start_version or 'old'}")
@@ -74,7 +76,9 @@ class UpgradeStep(ABC):
         return version in cls._steps
 
     @classmethod
-    def upgrade(cls, config, start_version, finish_version, config_filename):
+    def upgrade(
+        cls, config, start_version, finish_version, config_filename, attempt_fixes=False
+    ):
         """
         Runs through all required upgrade steps (i.e. relevant subclasses of UpgradeStep).
         Calls UpgradeStep.upgrade_step for each.
@@ -93,7 +97,12 @@ class UpgradeStep(ABC):
         current_start_version = start_version
         for stepcls in [cls._steps[str(v)] for v in step_versions]:
             step = stepcls()
-            config = step.upgrade_step(config, current_start_version, config_filename)
+            config = step.upgrade_step(
+                config,
+                current_start_version,
+                config_filename,
+                attempt_fixes=attempt_fixes,
+            )
             current_start_version = step.get_version()
             print("\n")
 
@@ -179,7 +188,9 @@ class UpgradeStep(ABC):
                 config["profiles"]["dask_worker"][k]["image"] = newimage
 
         # Run any version-specific tasks
-        return self._version_specific_upgrade(config, start_version, config_filename)
+        return self._version_specific_upgrade(
+            config, start_version, config_filename, *args, **kwargs
+        )
 
     def _version_specific_upgrade(
         self, config, start_version, config_filename, *args, **kwargs
@@ -215,10 +226,32 @@ class Upgrade_0_3_14(UpgradeStep):
         """
         Upgrade to Keycloak.
         """
-        # Create a group/user import file for Keycloak
         security = config.get("security", {})
         users = security.get("users", {})
         groups = security.get("groups", {})
+
+        # Custom Authenticators are no longer allowed
+        if (
+            config.get("security", {}).get("authentication", {}).get("type", "")
+            == "custom"
+        ):
+            customauth_warning = (
+                f"Custom Authenticators are no longer supported in {self.version} because Keycloak "
+                "manages all authentication.\nYou need to find a way to support your authentication "
+                "requirements within Keycloak."
+            )
+            if not kwargs.get("attempt_fixes", False):
+                raise ValueError(
+                    f"{customauth_warning}\n\nRun `qhub upgrade --attempt-fixes` to switch to basic Keycloak authentication instead."
+                )
+            else:
+                print(f"\nWARNING: {customauth_warning}")
+                print(
+                    "\nSwitching to basic Keycloak authentication instead since you specified --attempt-fixes."
+                )
+                config["security"]["authentication"] = {"type": "password"}
+
+        # Create a group/user import file for Keycloak
 
         realm_import_filename = config_filename.parent / "qhub-users-import.json"
 
@@ -227,9 +260,14 @@ class Upgrade_0_3_14(UpgradeStep):
             {
                 "username": k,
                 "enabled": True,
-                "groups": list(
-                    ({v.get("primary_group", "")} | set(v.get("secondary_groups", [])))
-                    - {""}
+                "groups": sorted(
+                    list(
+                        (
+                            {v.get("primary_group", "")}
+                            | set(v.get("secondary_groups", []))
+                        )
+                        - {""}
+                    )
                 ),
             }
             for k, v in users.items()

--- a/tests/qhub-config-yaml-files-for-upgrade/qhub-config-do-310-customauth.yaml
+++ b/tests/qhub-config-yaml-files-for-upgrade/qhub-config-do-310-customauth.yaml
@@ -1,0 +1,136 @@
+project_name: do-pytest
+provider: do
+domain: do.qhub.dev
+certificate:
+  type: self-signed
+security:
+  authentication:
+    type: custom
+    authentication_class: 'firstuseauthenticator.FirstUseAuthenticator'
+    config:
+       min_password_length: 5
+  users:
+    example-user:
+      uid: 1000
+      primary_group: admin
+      secondary_groups:
+      - users
+      password: $2b$12$YrEkTAEFfo4fKO7lYPpReegKagd1irrW5YmRugJcaPCjkVaPzrVLq
+  groups:
+    users:
+      gid: 100
+    admin:
+      gid: 101
+default_images:
+  jupyterhub: quansight/qhub-jupyterhub:v0.3.10
+  jupyterlab: quansight/qhub-jupyterlab:v0.3.10
+  dask_worker: quansight/qhub-dask-worker:v0.3.10
+  dask_gateway: quansight/qhub-dask-gateway:v0.3.10
+storage:
+  conda_store: 60Gi
+  shared_filesystem: 100Gi
+theme:
+  jupyterhub:
+    hub_title: QHub - do-pytest
+    hub_subtitle: Autoscaling Compute Environment on Digital Ocean
+    welcome: Welcome to do.qhub.dev. It is maintained by <a href="http://quansight.com">Quansight
+      staff</a>. The hub's configuration is stored in a github repository based on
+      <a href="https://github.com/Quansight/qhub/">https://github.com/Quansight/qhub/</a>.
+      To provide feedback and report any technical problems, please use the <a href="https://github.com/Quansight/qhub/issues">github
+      issue tracker</a>.
+    logo: /hub/custom/images/jupyter_qhub_logo.svg
+    primary_color: '#4f4173'
+    secondary_color: '#957da6'
+    accent_color: '#32C574'
+    text_color: '#111111'
+    h1_color: '#652e8e'
+    h2_color: '#652e8e'
+cdsdashboards:
+  enabled: true
+  cds_hide_user_named_servers: true
+  cds_hide_user_dashboard_servers: false
+terraform_state:
+  type: remote
+namespace: dev
+digital_ocean:
+  region: nyc3
+  kubernetes_version: 1.21.5-do.0
+  node_groups:
+    general:
+      instance: s-2vcpu-4gb
+      min_nodes: 1
+      max_nodes: 1
+    user:
+      instance: g-2vcpu-8gb
+      min_nodes: 1
+      max_nodes: 5
+    worker:
+      instance: g-2vcpu-8gb
+      min_nodes: 1
+      max_nodes: 5
+profiles:
+  jupyterlab:
+  - display_name: Small Instance
+    description: Stable environment with 1 cpu / 4 GB ram
+    default: true
+    kubespawner_override:
+      cpu_limit: 1
+      cpu_guarantee: 0.75
+      mem_limit: 4G
+      mem_guarantee: 2.5G
+      image: quansight/qhub-jupyterlab:v0.3.10
+  - display_name: Medium Instance
+    description: Stable environment with 2 cpu / 8 GB ram
+    kubespawner_override:
+      cpu_limit: 2
+      cpu_guarantee: 1.5
+      mem_limit: 8G
+      mem_guarantee: 5G
+      image: quansight/qhub-jupyterlab:v0.3.10
+  dask_worker:
+    Small Worker:
+      worker_cores_limit: 1
+      worker_cores: 0.75
+      worker_memory_limit: 4G
+      worker_memory: 2.5G
+      worker_threads: 1
+      image: quansight/qhub-dask-worker:v0.3.10
+    Medium Worker:
+      worker_cores_limit: 2
+      worker_cores: 1.5
+      worker_memory_limit: 8G
+      worker_memory: 5G
+      worker_threads: 2
+      image: quansight/qhub-dask-worker:v0.3.10
+environments:
+  environment-dask.yaml:
+    name: dask
+    channels:
+    - conda-forge
+    dependencies:
+    - python
+    - ipykernel
+    - ipywidgets
+    - python-graphviz
+    - dask ==2.30.0
+    - distributed ==2.30.1
+    - dask-gateway ==0.9.0
+    - numpy
+    - numba
+    - pandas
+  environment-dashboard.yaml:
+    name: dashboard
+    channels:
+    - conda-forge
+    dependencies:
+    - python
+    - ipykernel
+    - ipywidgets >=7.6
+    - param
+    - python-graphviz
+    - matplotlib >=3.3.4
+    - panel >=0.10.3
+    - voila >=0.2.7
+    - streamlit >=0.76
+    - dash >=1.19
+    - cdsdashboards-singleuser >=0.5.6

--- a/tests/qhub-config-yaml-files-for-upgrade/qhub-config-do-310.yaml
+++ b/tests/qhub-config-yaml-files-for-upgrade/qhub-config-do-310.yaml
@@ -1,0 +1,133 @@
+project_name: do-pytest
+provider: do
+domain: do.qhub.dev
+certificate:
+  type: self-signed
+security:
+  authentication:
+    type: password
+  users:
+    example-user:
+      uid: 1000
+      primary_group: admin
+      secondary_groups:
+      - users
+      password: $2b$12$YrEkTAEFfo4fKO7lYPpReegKagd1irrW5YmRugJcaPCjkVaPzrVLq
+  groups:
+    users:
+      gid: 100
+    admin:
+      gid: 101
+default_images:
+  jupyterhub: quansight/qhub-jupyterhub:v0.3.10
+  jupyterlab: quansight/qhub-jupyterlab:v0.3.10
+  dask_worker: quansight/qhub-dask-worker:v0.3.10
+  dask_gateway: quansight/qhub-dask-gateway:v0.3.10
+storage:
+  conda_store: 60Gi
+  shared_filesystem: 100Gi
+theme:
+  jupyterhub:
+    hub_title: QHub - do-pytest
+    hub_subtitle: Autoscaling Compute Environment on Digital Ocean
+    welcome: Welcome to do.qhub.dev. It is maintained by <a href="http://quansight.com">Quansight
+      staff</a>. The hub's configuration is stored in a github repository based on
+      <a href="https://github.com/Quansight/qhub/">https://github.com/Quansight/qhub/</a>.
+      To provide feedback and report any technical problems, please use the <a href="https://github.com/Quansight/qhub/issues">github
+      issue tracker</a>.
+    logo: /hub/custom/images/jupyter_qhub_logo.svg
+    primary_color: '#4f4173'
+    secondary_color: '#957da6'
+    accent_color: '#32C574'
+    text_color: '#111111'
+    h1_color: '#652e8e'
+    h2_color: '#652e8e'
+cdsdashboards:
+  enabled: true
+  cds_hide_user_named_servers: true
+  cds_hide_user_dashboard_servers: false
+terraform_state:
+  type: remote
+namespace: dev
+digital_ocean:
+  region: nyc3
+  kubernetes_version: 1.21.5-do.0
+  node_groups:
+    general:
+      instance: s-2vcpu-4gb
+      min_nodes: 1
+      max_nodes: 1
+    user:
+      instance: g-2vcpu-8gb
+      min_nodes: 1
+      max_nodes: 5
+    worker:
+      instance: g-2vcpu-8gb
+      min_nodes: 1
+      max_nodes: 5
+profiles:
+  jupyterlab:
+  - display_name: Small Instance
+    description: Stable environment with 1 cpu / 4 GB ram
+    default: true
+    kubespawner_override:
+      cpu_limit: 1
+      cpu_guarantee: 0.75
+      mem_limit: 4G
+      mem_guarantee: 2.5G
+      image: quansight/qhub-jupyterlab:v0.3.10
+  - display_name: Medium Instance
+    description: Stable environment with 2 cpu / 8 GB ram
+    kubespawner_override:
+      cpu_limit: 2
+      cpu_guarantee: 1.5
+      mem_limit: 8G
+      mem_guarantee: 5G
+      image: quansight/qhub-jupyterlab:v0.3.10
+  dask_worker:
+    Small Worker:
+      worker_cores_limit: 1
+      worker_cores: 0.75
+      worker_memory_limit: 4G
+      worker_memory: 2.5G
+      worker_threads: 1
+      image: quansight/qhub-dask-worker:v0.3.10
+    Medium Worker:
+      worker_cores_limit: 2
+      worker_cores: 1.5
+      worker_memory_limit: 8G
+      worker_memory: 5G
+      worker_threads: 2
+      image: quansight/qhub-dask-worker:v0.3.10
+environments:
+  environment-dask.yaml:
+    name: dask
+    channels:
+    - conda-forge
+    dependencies:
+    - python
+    - ipykernel
+    - ipywidgets
+    - python-graphviz
+    - dask ==2.30.0
+    - distributed ==2.30.1
+    - dask-gateway ==0.9.0
+    - numpy
+    - numba
+    - pandas
+  environment-dashboard.yaml:
+    name: dashboard
+    channels:
+    - conda-forge
+    dependencies:
+    - python
+    - ipykernel
+    - ipywidgets >=7.6
+    - param
+    - python-graphviz
+    - matplotlib >=3.3.4
+    - panel >=0.10.3
+    - voila >=0.2.7
+    - streamlit >=0.76
+    - dash >=1.19
+    - cdsdashboards-singleuser >=0.5.6

--- a/tests/qhub-config-yaml-files-for-upgrade/qhub-users-import.json
+++ b/tests/qhub-config-yaml-files-for-upgrade/qhub-users-import.json
@@ -6,8 +6,8 @@
       "username": "example-user",
       "enabled": true,
       "groups": [
-        "users",
-        "admin"
+        "admin",
+        "users"
       ]
     }
   ],

--- a/tests/qhub-config-yaml-files-for-upgrade/qhub-users-import.json
+++ b/tests/qhub-config-yaml-files-for-upgrade/qhub-users-import.json
@@ -1,0 +1,15 @@
+{
+  "id": "qhub",
+  "realm": "qhub",
+  "users": [
+    {
+      "username": "example-user",
+      "enabled": true,
+      "groups": [
+        "users",
+        "admin"
+      ]
+    }
+  ],
+  "groups": []
+}

--- a/tests/scripts/minikube-loadbalancer-ip.py
+++ b/tests/scripts/minikube-loadbalancer-ip.py
@@ -4,25 +4,34 @@ import os
 import sys
 import subprocess
 
-docker_image_cmd = ['docker', 'ps', '--format', '{{.Names}} {{.ID}}']
-docker_images_output = subprocess.check_output(docker_image_cmd, encoding='utf-8')[:-1]
-docker_images = {line.split()[0]: line.split()[1] for line in docker_images_output.split('\n')}
+docker_image_cmd = ["docker", "ps", "--format", "{{.Names}} {{.ID}}"]
+docker_images_output = subprocess.check_output(docker_image_cmd, encoding="utf-8")[:-1]
+docker_images = {
+    line.split()[0]: line.split()[1] for line in docker_images_output.split("\n")
+}
 
-if 'minikube' not in docker_images:
-    print('minikube docker image not running')
+if "minikube" not in docker_images:
+    print("minikube docker image not running")
     sys.exit(1)
 
-docker_inspect_cmd = ['docker', 'inspect', '--format={{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}', docker_images['minikube']]
-address = subprocess.check_output(docker_inspect_cmd, encoding='utf-8')[:-1].split('.')
+docker_inspect_cmd = [
+    "docker",
+    "inspect",
+    "--format={{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}",
+    docker_images["minikube"],
+]
+address = subprocess.check_output(docker_inspect_cmd, encoding="utf-8")[:-1].split(".")
 
-filename = os.path.expanduser('~/.minikube/profiles/minikube/config.json')
+filename = os.path.expanduser("~/.minikube/profiles/minikube/config.json")
 with open(filename) as f:
     data = json.load(f)
 
-start_address, end_address = '.'.join(address[0:3] + ['100']), '.'.join(address[0:3] + ['150'])
-print('Setting start=%s end=%s' % (start_address, end_address))
-data['KubernetesConfig']['LoadBalancerStartIP'] = start_address
-data['KubernetesConfig']['LoadBalancerEndIP'] = end_address
+start_address, end_address = ".".join(address[0:3] + ["100"]), ".".join(
+    address[0:3] + ["150"]
+)
+print("Setting start=%s end=%s" % (start_address, end_address))
+data["KubernetesConfig"]["LoadBalancerStartIP"] = start_address
+data["KubernetesConfig"]["LoadBalancerEndIP"] = end_address
 
-with open(filename, 'w') as f:
+with open(filename, "w") as f:
     json.dump(data, f)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -13,9 +13,7 @@ from qhub.initialize import render_config
         ("azure-pytest", "dev", "azure.qhub.dev", "azure", "github-actions", "github"),
     ],
 )
-def test_schema(
-    project, namespace, domain, cloud_provider, ci_provider, auth_provider
-):
+def test_schema(project, namespace, domain, cloud_provider, ci_provider, auth_provider):
     config = render_config(
         project_name=project,
         namespace=namespace,

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,0 +1,49 @@
+import pytest
+from pathlib import Path
+
+from qhub.upgrade import do_upgrade, __version__, load_yaml, verify
+
+
+@pytest.mark.parametrize(
+    "old_qhub_config_path_str",
+    [
+        ("./qhub-config-yaml-files-for-upgrade/qhub-config-do-310.yaml"),
+    ],
+)
+def test_upgrade(tmp_path, old_qhub_config_path_str):
+    old_qhub_config_path = Path(__file__).parent / old_qhub_config_path_str
+
+    tmp_qhub_config = Path(tmp_path, old_qhub_config_path.name)
+    tmp_qhub_config.write_text(old_qhub_config_path.read_text())  # Copy contents to tmp
+
+    orig_contents = tmp_qhub_config.read_text()  # Read in initial contents
+
+    # Do the updgrade
+    do_upgrade(tmp_qhub_config)
+
+    # Check the resulting YAML
+    config = load_yaml(tmp_qhub_config)
+
+    verify(
+        config
+    )  # Would raise an error if invalid by current QHub version's standards
+
+    assert len(config["security"]["keycloak"]["initial_root_password"]) == 16
+
+    assert "users" not in config["security"]
+    assert "groups" not in config["security"]
+
+    # Check image versions have been bumped up
+    assert (
+        config["default_images"]["jupyterhub"]
+        == f"quansight/qhub-jupyterhub:v{__version__}"
+    )
+    assert (
+        config["profiles"]["jupyterlab"][0]["kubespawner_override"]["image"]
+        == f"quansight/qhub-jupyterlab:v{__version__}"
+    )
+
+    # Check backup
+    tmp_qhub_config_backup = Path(tmp_path, f"{old_qhub_config_path.name}.old.backup")
+
+    assert orig_contents == tmp_qhub_config_backup.read_text()

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -4,13 +4,25 @@ from pathlib import Path
 from qhub.upgrade import do_upgrade, __version__, load_yaml, verify
 
 
+@pytest.fixture
+def qhub_users_import_json():
+    return (
+        (
+            Path(__file__).parent
+            / "./qhub-config-yaml-files-for-upgrade/qhub-users-import.json"
+        )
+        .read_text()
+        .rstrip()
+    )
+
+
 @pytest.mark.parametrize(
     "old_qhub_config_path_str",
     [
         ("./qhub-config-yaml-files-for-upgrade/qhub-config-do-310.yaml"),
     ],
 )
-def test_upgrade(tmp_path, old_qhub_config_path_str):
+def test_upgrade(tmp_path, old_qhub_config_path_str, qhub_users_import_json):
     old_qhub_config_path = Path(__file__).parent / old_qhub_config_path_str
 
     tmp_qhub_config = Path(tmp_path, old_qhub_config_path.name)
@@ -41,6 +53,11 @@ def test_upgrade(tmp_path, old_qhub_config_path_str):
     assert (
         config["profiles"]["jupyterlab"][0]["kubespawner_override"]["image"]
         == f"quansight/qhub-jupyterlab:v{__version__}"
+    )
+
+    # Keycloak import users json
+    assert (
+        Path(tmp_path, "qhub-users-import.json").read_text() == qhub_users_import_json
     )
 
     # Check backup


### PR DESCRIPTION
Fixes #931 - qhub upgrade should reject custom authenticators [bug]

## Changes:

- Running `qhub upgrade` will throw an error advising that custom authenticators are no longer supported.
- Users will be told they can run `qhub upgrade --attempt-fixes` instead. This will change the `qhub-config.yaml` to the basic Keycloak password authentication.
- Pytests added for upgrade command, including 'normal yaml from v3.10' and custom authenticator (resulting in error, or being fixed by --attempt-fixes)

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [x] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [x] Yes
- [ ] No

## Further comments (optional)

I decided not to pollute documentation with a description of the --attempt-fixes flag since that is self-documenting - it reveals itself if it is needed, and will ideally give the user a chance to understand and think about the pros and cons first.

In pytests for test_upgrade.py, the YAML loading would ideally be a fixture, but maybe not worth changing.
