### PR TITLE
qhub destroy using targets

### DIFF
--- a/qhub/cli/destroy.py
+++ b/qhub/cli/destroy.py
@@ -23,6 +23,11 @@ def create_destroy_subcommand(subparser):
         action="store_true",
         help="Disable auto-rendering before destroy",
     )
+    subparser.add_argument(
+        "--full-only",
+        action="store_true",
+        help="Only carry out one full pass instead of targeted sections",
+    )
     subparser.set_defaults(func=handle_destroy)
 
 
@@ -43,4 +48,5 @@ def handle_destroy(args):
     destroy_configuration(
         config,
         args.skip_remote_state_provision,
+        args.full_only,
     )

--- a/qhub/destroy.py
+++ b/qhub/destroy.py
@@ -7,10 +7,10 @@ from qhub.state import terraform_state_sync
 logger = logging.getLogger(__name__)
 
 
-def destroy_configuration(config, skip_remote_state_provision=False):
+def destroy_configuration(config, skip_remote_state_provision=False, full_only=False):
     logger.info(
-        """Removing all infrastructure, your local files will still remain, \n
-    you can use 'qhub deploy' to re - install infrastructure using same config file"""
+        """Removing all infrastructure, your local files will still remain,
+    you can use 'qhub deploy' to re-install infrastructure using same config file\n"""
     )
 
     with timer(logger, "destroying QHub"):
@@ -20,7 +20,82 @@ def destroy_configuration(config, skip_remote_state_provision=False):
         # 02 Remove all infrastructure
         terraform.init(directory="infrastructure")
         terraform.refresh(directory="infrastructure")
-        terraform.destroy(directory="infrastructure")
+
+        if not full_only:
+            stages = (
+                {
+                    "name": "General cluster software",
+                    "targets": [
+                        "module.kubernetes-nfs-mount",
+                        "module.kubernetes-nfs-server",
+                        "module.kubernetes-nfs-mount",
+                        "module.kubernetes-conda-store-server",
+                        "module.kubernetes-conda-store-mount",
+                        "module.kubernetes-autoscaling",
+                        "module.qhub",
+                        "module.prefect",
+                        "module.monitoring",
+                        "module.clearml",
+                        "module.forwardauth",
+                        "random_password.jupyterhub-jhsecret",
+                        "random_password.forwardauth-jhsecret",
+                        "kubernetes_secret.qhub_yaml_secret",
+                    ]
+                    + [
+                        f"module.{helmext['name']}-extension"
+                        for helmext in config.get("helm_extensions", [])
+                    ]
+                    + [
+                        f"module.ext-{ext['name']}"
+                        for ext in config.get("extensions", [])
+                    ],
+                },
+                {
+                    "name": "Keycloak Config",
+                    "targets": [
+                        "module.kubernetes-keycloak-config",
+                        "random_password.keycloak-qhub-bot-password",
+                    ],
+                },
+                {
+                    "name": "Keycloak Helm installation",
+                    "targets": ["module.kubernetes-keycloak-helm"],
+                },
+                {
+                    "name": "Kubernetes Ingress",
+                    "targets": ["module.kubernetes-ingress"],
+                },
+                {
+                    "name": "Kubernetes Cluster",
+                    "targets": [
+                        "module.kubernetes",
+                        "module.kubernetes-initialization",
+                    ],
+                },
+                {
+                    "name": "Cloud Infrastructure",
+                    "targets": [
+                        "module.registry-jupyterhub",  # GCP
+                        "module.efs",  # AWS
+                        "module.registry-jupyterlab",  # AWS
+                        "module.network",  # AWS
+                        "module.accounting",  # AWS
+                        "module.registry",  # Azure
+                    ],
+                },
+            )
+
+            for stageinfo in stages:
+                logger.info(
+                    f"Running Terraform Stage: {stageinfo['name']} {stageinfo['targets']}"
+                )
+                terraform.destroy(
+                    directory="infrastructure", targets=stageinfo["targets"]
+                )
+
+        else:
+            logger.info("Running Terraform Stage: FULL")
+            terraform.destroy(directory="infrastructure")
 
         # 03 Remove terraform backend remote state bucket
         # backwards compatible with `qhub-config.yaml` which

--- a/qhub/provider/terraform.py
+++ b/qhub/provider/terraform.py
@@ -115,12 +115,14 @@ def refresh(directory=None):
         run_terraform_subprocess(command, cwd=directory, prefix="terraform")
 
 
-def destroy(directory=None):
-    logger.info(f"terraform destroy directory={directory}")
+def destroy(directory=None, targets=None):
+    targets = targets or []
+
+    logger.info(f"terraform destroy directory={directory} targets={targets}")
     command = [
         "destroy",
         "-auto-approve",
-    ]
+    ] + ["-target=" + _ for _ in targets]
 
     with timer(logger, "terraform destroy"):
         run_terraform_subprocess(command, cwd=directory, prefix="terraform")


### PR DESCRIPTION
# Problem 

There are many reasons why `qhub destroy` fails, including timeouts in terraform which are hard to set globally.

Sometimes the Kubernetes cluster starts to be destroyed before Terraform has formally had a chance to destroy some of the software deployed within Kubernetes, resulting in the error that the cluster is not accessible to destroy that software.

Since the Keycloak provider needs to make API calls to Keycloak within the cluster, terraform command can fail terminally if the provider is configured with a Keycloak URL that no longer exists.

# Other Solutions

A more robust definition system as proposed in [Split infrastructure into components](#847) might help since it would allow destroy to be done in stages, so we can be sure one stage is complete before we advance to the next.

Maybe a move to Terraform CDK would also change this.

But these are long-term ideas.

# Current Solution

In this PR I have changed `qhub destroy` just to run the reverse of the targetted `qhub deploy` stages that we already have. One difficulty is in listing out all items that need to be destroyed at each stage - since deploy's final stage is just 'everything else', we need to maintain a long list of all items. I don't believe my list is complete, but it doesn't really matter - the destruction of Kubernetes should destroy everything anyway, and removing most items from the cluster in a separate stage gives breathing room so there is less to remove during the cluster destroy.

The main thing that we need to avoid telling Terraform to destroy e.g. "Kubernetes" and "keycloak-configuration" in the same stage, which of course happens when we just run a straight `terraform destroy` with no targetting.

An alternative approach to all this may have been to strengthen the 'depends_on' tree but this is split across multiple files and is still likely to run into the timeout problem.

Note it is not possible to 'refresh state' once Keycloak is inaccessible. We should consider removing the `terraform refresh` command from the destroy procedure anyway.

It is possible to run the old style of `qhub destroy` without targets  by using the flag `--full-only`.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [x] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

