### PR TITLE
Add timeout to terraform import command

### DIFF
--- a/qhub/provider/terraform.py
+++ b/qhub/provider/terraform.py
@@ -98,9 +98,10 @@ def output(directory=None):
 
 def tfimport(addr, id, directory=None):
     logger.info(f"terraform import directory={directory} addr={addr} id={id}")
-    command = ["import", addr, id]
+    command = ["timeout", "30s", "--signal=9", "import", addr, id]
     with timer(logger, "terraform import"):
         run_terraform_subprocess(
+            
             command, cwd=directory, prefix="terraform", strip_errors=True
         )
 

--- a/qhub/provider/terraform.py
+++ b/qhub/provider/terraform.py
@@ -101,7 +101,6 @@ def tfimport(addr, id, directory=None):
     command = ["timeout", "30s", "--signal=9", "import", addr, id]
     with timer(logger, "terraform import"):
         run_terraform_subprocess(
-            
             command, cwd=directory, prefix="terraform", strip_errors=True
         )
 


### PR DESCRIPTION
Fixes #933

## Changes:

Adds a timeout to the subprocess for `terraform import` of 30 seconds. Without this timeout deploying on GCP will hang and give the error that that the bucket doesn't exist

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [ ] Yes
- [x] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No
