### PR TITLE
Take AWS region from AWS_DEFAULT_REGION into qhub-config.yaml on init…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v2.3.0
     hooks:
     -   id: check-yaml
+        exclude: 'qhub/template/\{\{ cookiecutter\.repo_directory \}\}/\.github/.*'
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
   - repo: https://github.com/psf/black

--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -386,6 +386,8 @@ def render_config(
         config["amazon_web_services"] = AMAZON_WEB_SERVICES
         if kubernetes_version:
             config["amazon_web_services"]["kubernetes_version"] = kubernetes_version
+        if "AWS_DEFAULT_REGION" in os.environ:
+            config["amazon_web_services"]["region"] = os.environ["AWS_DEFAULT_REGION"]
     elif cloud_provider == "local":
         config["theme"]["jupyterhub"][
             "hub_subtitle"

--- a/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/qhub-ops.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/qhub-ops.yaml
@@ -13,7 +13,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+  AWS_DEFAULT_REGION: ${{ cookiecutter.amazon_web_services.region }}
 {% endraw %}
 {% elif cookiecutter.provider == 'do' %}
 {% raw %}

--- a/scripts/aws-force-destroy.py
+++ b/scripts/aws-force-destroy.py
@@ -258,9 +258,9 @@ def force_destroy_configuration(config):
                     for ni in subnet.network_interfaces.all():
                         ni.load()
                         # But can only detach if attached...
-                        ni.detach(DryRun=False, Force=True)
-
-                        ni.delete()
+                        if ni.attachment:
+                            ni.detach(DryRun=False, Force=True)
+                            ni.delete()
 
                     logging.info(f"Delete subnet {r['resource']}")
                     subnet.delete(DryRun=False)


### PR DESCRIPTION
…, but otherwise always respect the setting in qhub-config.yaml

## Changes:

- Ensures AWS region specified in qhub-config.yaml is always respected
- Allows user to change that via AWS_DEFAULT_REGION env var going into `qhub init`

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [x] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

## Further comments (optional)


