### PR TITLE
kubernetes-initialization depends_on kubernetes

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/qhub-ops.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/qhub-ops.yaml
@@ -13,8 +13,8 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  AWS_DEFAULT_REGION: ${{ cookiecutter.amazon_web_services.region }}
 {% endraw %}
+  AWS_DEFAULT_REGION: {{ cookiecutter.amazon_web_services.region }}
 {% elif cookiecutter.provider == 'do' %}
 {% raw %}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
@@ -51,6 +51,12 @@ module "kubernetes-initialization" {
 
   namespace = var.environment
   secrets   = []
+
+{% if cookiecutter.provider != "local" %}
+  depends_on = [
+    module.kubernetes
+  ]
+{% endif %}
 }
 
 


### PR DESCRIPTION
In AWS integration tests, sometimes we see namespace is trying to be created before cluster is fully up.

Terraform should maybe spot this dependency anyway since provider needs to use outputs but maybe this will help.

## Changes:

- kubernetes-initialization depends_on kubernetes

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [x] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

