### PR TITLE
Remove user/groups from YAML

### DIFF
--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -191,19 +191,6 @@ class GitHubAuthentication(Authentication):
     config: GitHubConfig
 
 
-# =========== Users and Groups =============
-
-
-class User(Base):
-    password: typing.Optional[str]
-    primary_group: typing.Optional[str]
-    secondary_groups: typing.Optional[typing.List[str]]
-
-
-class Group(Base):
-    gid: typing.Optional[int]
-
-
 # ================= Keycloak ==================
 
 
@@ -217,10 +204,6 @@ class Keycloak(Base):
 
 class Security(Base):
     authentication: Authentication
-    users: typing.Optional[typing.Dict[str, typing.Union[User, None]]]
-    groups: typing.Optional[
-        typing.Dict[str, typing.Union[Group, None]]
-    ]  # If gid is omitted, no attributes in Group means it appears as None
     keycloak: typing.Optional[Keycloak]
 
 

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
@@ -240,12 +240,6 @@ module "kubernetes-keycloak-config" {
   jupyterhub-keycloak-client-id     = local.jupyterhub-keycloak-client-id
   jupyterhub-keycloak-client-secret = random_password.jupyterhub-jhsecret.result
 
-  users = jsondecode("{{ cookiecutter.tf_users | jsonify | replace('"', '\\"') }}")
-
-  groups = jsondecode("{{ cookiecutter.tf_groups | jsonify | replace('"', '\\"') }}")
-
-  user_groups = jsondecode("{{ cookiecutter.tf_user_groups | jsonify | replace('"', '\\"') }}")
-
   {% if cookiecutter.security.authentication.type == "GitHub" -%}
   github_client_id     = {{ cookiecutter.security.authentication.config.client_id | jsonify }}
   github_client_secret = {{ cookiecutter.security.authentication.config.client_secret | jsonify }}

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/keycloak-config/main.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/keycloak-config/main.tf
@@ -15,60 +15,30 @@ resource "keycloak_realm" "realm-qhub" {
   display_name = "QHub ${var.name}"
 }
 
-resource "keycloak_user" "user" {
-  count = length(var.users)
-
+resource "keycloak_group" "admingroup" {
   realm_id = keycloak_realm.realm-qhub.id
-
-  username = var.users[count.index].name
-  enabled  = true
-  email    = var.users[count.index].email
+  name     = "admin"
 
   lifecycle {
     ignore_changes = all
-  }
-
-  dynamic "initial_password" {
-    for_each = [for pwd in [var.users[count.index].password] : pwd if pwd != ""]
-    content {
-      value     = initial_password.value
-      temporary = false
-    }
   }
 }
 
-resource "keycloak_group" "group" {
-  count = length(var.groups)
-
+resource "keycloak_group" "usersgroup" {
   realm_id = keycloak_realm.realm-qhub.id
-  name     = var.groups[count.index].name
+  name     = "users"
 
   lifecycle {
     ignore_changes = all
   }
-
 }
 
 resource "keycloak_default_groups" "default" {
   realm_id = keycloak_realm.realm-qhub.id
 
   group_ids = [
-    for g in keycloak_group.group : g.id if g.name == "users"
+    keycloak_group.usersgroup.id
   ]
-}
-
-resource "keycloak_user_groups" "user_groups" {
-  count = length(var.user_groups)
-
-  realm_id = keycloak_realm.realm-qhub.id
-
-  user_id = keycloak_user.user[count.index].id
-
-  group_ids = [
-    for i in var.user_groups[count.index] : keycloak_group.group[i].id
-  ]
-
-  exhaustive = false
 }
 
 resource "keycloak_openid_client" "qhub_client" {

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/keycloak-config/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/keycloak-config/variables.tf
@@ -43,24 +43,6 @@ variable "name" {
   type        = string
 }
 
-variable "users" {
-  description = "list of users data"
-  type        = list(map(any))
-  default     = []
-}
-
-variable "groups" {
-  description = "list of groups data"
-  type        = list(map(any))
-  default     = []
-}
-
-variable "user_groups" {
-  description = "list of user_groups data"
-  type        = list(list(number))
-  default     = []
-}
-
 variable "github_client_id" {
   description = "GitHub OAuth2 Client ID"
   type        = string
@@ -90,4 +72,3 @@ variable "auth0_subdomain" {
   type        = string
   default     = ""
 }
-


### PR DESCRIPTION
Fixes #920 

## Changes:

- No longer allows `security.users` and `security.groups` in `qhub-config.yaml`

This means that all user management must now be in Keycloak.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [x] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [x] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No
