### PR TITLE
Merge hub.extraEnv env vars

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v2.3.0
     hooks:
     -   id: check-yaml
-        exclude: 'qhub/template/\{\{ cookiecutter\.repo_directory \}\}/\.github/.*'
+        exclude: 'qhub/template/\{\{ cookiecutter\.repo_directory \}\}/(\.github/.*|infrastructure/jupyterhub.yaml)'
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
   - repo: https://github.com/psf/black

--- a/docs/source/admin_guide/jupyterhub.md
+++ b/docs/source/admin_guide/jupyterhub.md
@@ -18,3 +18,7 @@ jupyterhub:
 ```
 
 Where it is possible to influence a value using 'native' QHub configuration, you should use that as a preference. For example, you would not set `jupyterhub.overrides.hub.image.name` to use a custom JupyterHub Docker image. Instead you would set `default_images.jupyterhub`.
+
+There is special behavior for the values `jupyterhub.overrides.hub.extraEnv` and `jupyterhub.overrides.hub.extraConfig`. Setting these would have naturally seen them be overridden in their entirety by QHub's own values, but there is special treatment whereby QHub's values are merged into the list of any values that you might have set as overrides.
+
+In general, it is possible that other overrides will always be lost where QHub sets its own values, so caution must be taken, and in debugging ensure that you are prepared for unexpected results when using overrides.

--- a/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterhub/environment.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterhub/environment.yaml
@@ -10,5 +10,5 @@ dependencies:
  - cdsdashboards==0.6.0
  - jupyterhub-idle-culler==1.0
  - pip:
-   - qhub-jupyterhub-theme==0.3.2
+   - qhub-jupyterhub-theme==0.3.3
    - python-keycloak==0.26.1

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/jupyterhub.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/jupyterhub.yaml
@@ -5,6 +5,12 @@ hub:
 {% include "templates/jupyterhub_config.py.j2" %}
 {% endfilter %}
 
+{% if cookiecutter.jupyterhub is defined and cookiecutter.jupyterhub.overrides is defined and cookiecutter.jupyterhub.overrides.hub is defined and cookiecutter.jupyterhub.overrides.hub.extraConfig is defined %}
+{% filter indent(width=4) %}
+{{ cookiecutter.jupyterhub.overrides.hub.extraConfig | default({}) | yamlify -}}
+{% endfilter %}
+{% endif %}
+
 singleuser:
   storage:
     homeMountPath: /home/jovyan

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
@@ -307,6 +307,10 @@ module "qhub" {
 {%- endif %}
   )
 
+{%- if cookiecutter.jupyterhub.overrides.hub.extraEnv is defined %}
+  jupyterhub-hub-extraEnv = {{- cookiecutter.jupyterhub.overrides.hub.extraEnv | default({}) | jsonify -}}
+{%- endif %}
+
   dask_gateway_extra_config = file("dask_gateway_config.py.j2")
 
   forwardauth-callback-url-path = local.forwardauth-callback-url-path

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
@@ -307,7 +307,7 @@ module "qhub" {
 {%- endif %}
   )
 
-{%- if cookiecutter.jupyterhub.overrides.hub.extraEnv is defined %}
+{%- if cookiecutter.jupyterhub is defined and cookiecutter.jupyterhub.overrides is defined and cookiecutter.jupyterhub.overrides.hub is defined and cookiecutter.jupyterhub.overrides.hub.extraEnv is defined %}
   jupyterhub-hub-extraEnv = {{- cookiecutter.jupyterhub.overrides.hub.extraEnv | default({}) | jsonify -}}
 {%- endif %}
 

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/meta/qhub/main.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/meta/qhub/main.tf
@@ -12,7 +12,8 @@ module "kubernetes-jupyterhub" {
   overrides = concat(var.jupyterhub-overrides, [
     jsonencode({
       hub = {
-        extraEnv = [
+        extraEnv = concat( var.jupyterhub-hub-extraEnv,
+          [
           {
             name = "OAUTH_CLIENT_ID",
             value = var.OAUTH_CLIENT_ID
@@ -57,7 +58,7 @@ module "kubernetes-jupyterhub" {
             name  = "KEYCLOAK_PASSWORD"
             value = var.keycloak_password
           }
-        ]
+        ])
         nodeSelector = {
           (var.general-node-group.key) = var.general-node-group.value
         }

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/meta/qhub/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/meta/qhub/variables.tf
@@ -88,6 +88,12 @@ variable "jupyterhub-overrides" {
   type        = list(string)
 }
 
+variable "jupyterhub-hub-extraEnv" {
+  description = "Extracted overrides to merge with jupyterhub.hub.extraEnv"
+  type        = list(map(any))
+  default     = []
+}
+
 variable "dask_gateway_extra_config" {
   description = "dask gateway extra configuration"
   type        = string

--- a/qhub/template/{{ cookiecutter.repo_directory }}/templates/jupyterhub_config.py.j2
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/templates/jupyterhub_config.py.j2
@@ -32,15 +32,11 @@ c.JupyterHub.extra_handlers = []
 
 # ==================== THEME =========================
 import tornado.web
-import qhub_jupyterhub_theme
+from qhub_jupyterhub_theme import theme_extra_handlers, theme_template_paths
 
-c.JupyterHub.extra_handlers += [
-    (r'/custom/(.*)', tornado.web.StaticFileHandler, {"path": qhub_jupyterhub_theme.STATIC_PATH}),
-]
+c.JupyterHub.extra_handlers += theme_extra_handlers
 
-c.JupyterHub.template_paths = [
-    qhub_jupyterhub_theme.TEMPLATE_PATH
-] + c.JupyterHub.template_paths
+c.JupyterHub.template_paths = theme_template_paths + c.JupyterHub.template_paths
 
 c.JupyterHub.template_vars = {
 {%- for key, value in cookiecutter.theme.jupyterhub.items() %}


### PR DESCRIPTION
Merge hub.extraEnv env vars and hub.extraConfig in jupyterhub helm chart.

## Changes:

If the following is in the qhub-config.yaml file:
```
jupyterhub:
  overrides:
    hub:
      config:
        Authenticator:
          enable_auth_state: true
      extraEnv:
      - name: "MYENV1"
        value: "11111"
      - name: "MYENV2"
        value: "22222"

      extraConfig:
        new-config-thing: |
          c.KubeSpawner.something = 123
```

then, despite the overrides supposed to be added to the JupyterHub Helm release, previously anything under `hub.extraEnv` would be lost when further overridden by QHub's own required env vars.

This PR merges them instead so the user's env vars should make it into the Hub pod.

Similarly for extraConfig.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [x] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No


