### PR TITLE
keycloak.realm_display_name

### DIFF
--- a/docs/source/admin_guide/keycloak.md
+++ b/docs/source/admin_guide/keycloak.md
@@ -12,6 +12,7 @@ To set a Helm override, for example:
 security:
   keycloak:
     initial_root_password: password123
+    realm_display_name: "Our Company QHub"
     overrides:
       extraEnv: |
         - name: KEYCLOAK_DEFAULT_THEME
@@ -27,3 +28,5 @@ security:
 If you do set `overrides.extraEnv` as above, you must remember to include `PROXY_ADDRESS_FORWARDING=true`. Otherwise, the Keycloak deployment will not work as you will have overridden an important default Helm value that's required by QHub.
 
 To find out more about using Keycloak in QHub, see [Installation - Login](../installation/login.md)
+
+The `security.keycloak.realm_display_name` setting is the text to display on the Keycloak login page for your QHub (and in some other locations). This is optional, and if omitted will default to "QHub <project_name>" where `project_name` is a field in the `qhub-config.yaml` file.

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -197,6 +197,7 @@ class GitHubAuthentication(Authentication):
 class Keycloak(Base):
     initial_root_password: typing.Optional[str]
     overrides: typing.Optional[typing.Dict]
+    realm_display_name: typing.Optional[str]
 
 
 # ============== Security ================

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
@@ -243,6 +243,8 @@ module "kubernetes-keycloak-config" {
 
   name = var.name
 
+  realm_display_name = {{ cookiecutter.security.keycloak.realm_display_name | default("QHub ${var.name}", true) | jsonify }}
+
   external-url = var.endpoint
 
   forwardauth-callback-url-path      = local.forwardauth-callback-url-path

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/keycloak-config/main.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/keycloak-config/main.tf
@@ -12,7 +12,7 @@ resource "keycloak_realm" "realm-qhub" {
 
   realm = "qhub"
 
-  display_name = "QHub ${var.name}"
+  display_name = var.realm_display_name
 }
 
 resource "keycloak_group" "admingroup" {

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/keycloak-config/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/keycloak-config/variables.tf
@@ -43,6 +43,11 @@ variable "name" {
   type        = string
 }
 
+variable "realm_display_name" {
+  description = "Display name for QHub realm"
+  type        = string
+}
+
 variable "github_client_id" {
   description = "GitHub OAuth2 Client ID"
   type        = string


### PR DESCRIPTION
## Changes:

- Adds an optional `security.keycloak.realm_display_name` setting to override the `qhub` realm display name, e.g. on the Keycloak login page.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [x] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered and more.
