### PR TITLE
Tweak node pool usage

### DIFF
--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
@@ -421,6 +421,7 @@ module "forwardauth" {
   namespace    = var.environment
   external-url = var.endpoint
 
+  node-group = local.node_groups.general
   jh-client-id      = local.forwardauth-keycloak-client-id
   jh-client-secret  = random_password.forwardauth-jhsecret.result
   callback-url-path = local.forwardauth-callback-url-path

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/forwardauth/main.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/forwardauth/main.tf
@@ -44,7 +44,21 @@ resource "kubernetes_deployment" "forwardauth-deployment" {
       }
 
       spec {
-
+        affinity {
+          node_affinity {
+            required_during_scheduling_ignored_during_execution {
+              node_selector_term {
+                match_expressions {
+                  key      = var.node-group.key
+                  operator = "In"
+                  values = [
+                    var.node-group.value
+                  ]
+                }
+              }
+            }
+          }
+        }
         container {
           # image = "thomseddon/traefik-forward-auth:2.2.0"
           # Use PR #159 https://github.com/thomseddon/traefik-forward-auth/pull/159

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/forwardauth/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/forwardauth/variables.tf
@@ -22,3 +22,11 @@ variable "callback-url-path" {
   description = "Path of Callback URL"
   type        = string
 }
+
+variable "node-group" {
+  description = "Node key value pair for bound general resources"
+  type = object({
+    key   = string
+    value = string
+  })
+}

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/clearml/chart/values.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/clearml/chart/values.yaml
@@ -226,6 +226,8 @@ redis: # configuration from https://github.com/bitnami/charts/blob/master/bitnam
   master:
     name: "{{ .Release.Name }}-redis-master"
     port: 6379
+    nodeSelector:
+      app: "clearml"
     persistence:
       enabled: true
       accessModes:
@@ -240,6 +242,8 @@ mongodb: # configuration from https://github.com/bitnami/charts/blob/master/bitn
     registry: docker.io
     repository: bitnami/mongodb
     tag: 3.6.21-debian-9-r71
+  nodeSelector:
+    app: "clearml"
   architecture: standalone
   auth:
     enabled: false

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/clearml/main.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/clearml/main.tf
@@ -53,4 +53,20 @@ resource "helm_release" "clearml" {
     }
   }
 
+  dynamic "set" {
+    for_each = var.node_selector
+    content {
+      name  = "mongodb.nodeSelector.${set.key}"
+      value = set.value
+    }
+  }
+
+  dynamic "set" {
+    for_each = var.node_selector
+    content {
+      name  = "redis.master.nodeSelector.${set.key}"
+      value = set.value
+    }
+  }
+
 }


### PR DESCRIPTION
Allocates some stray cleaml resources to the clearml node-pool and targets the forwardauth deployment resource to the general node pool.
