### PR TITLE
make the commit of the terraform rendering optional

### DIFF
--- a/qhub/render/__init__.py
+++ b/qhub/render/__init__.py
@@ -10,7 +10,7 @@ from ruamel.yaml import YAML
 from cookiecutter.generate import generate_files
 from ..version import __version__
 from ..constants import TERRAFORM_VERSION
-from ..utils import pip_install_qhub, QHUB_GH_BRANCH
+from ..utils import pip_install_qhub, QHUB_GH_BRANCH, QHUB_PREVENT_COMMIT_RENDER
 
 # existing files and folders to delete when `render_template` is called
 DELETABLE_PATHS = [
@@ -59,6 +59,8 @@ def patch_versioning_extra_config(config):
     config["pip_install_qhub"] = pip_install_qhub
 
     config["QHUB_GH_BRANCH"] = QHUB_GH_BRANCH
+
+    config["QHUB_PREVENT_COMMIT_RENDER"] = QHUB_PREVENT_COMMIT_RENDER
 
     if "terraform_version" not in config:
         config["terraform_version"] = TERRAFORM_VERSION

--- a/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/qhub-ops.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/.github/workflows/qhub-ops.yaml
@@ -68,6 +68,8 @@ jobs:
       - name: Deploy Changes made in qhub-config.yaml
         run: |
           qhub deploy -c qhub-config.yaml --disable-prompt {% if cookiecutter.QHUB_GH_BRANCH == '' %}--skip-remote-state-provision{% endif %}
+
+{% if cookiecutter.QHUB_PREVENT_COMMIT_RENDER != 'yes' -%}
       - name: Push Changes
         run: |
           git config user.email "qhub@quansight.com"
@@ -78,3 +80,4 @@ jobs:
         env:
           COMMIT_MSG: |
             qhub-config.yaml automated commit: {{ '${{ github.sha }}' }}
+{% endif %}

--- a/qhub/template/{{ cookiecutter.repo_directory }}/.gitlab-ci.yml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/.gitlab-ci.yml
@@ -21,10 +21,12 @@ render-qhub:
     - git checkout "{{ cookiecutter.ci_cd.branch }}"
     - {{ cookiecutter.pip_install_qhub }}
     - qhub deploy --config qhub-config.yaml --disable-prompt --skip-remote-state-provision
+{% if cookiecutter.QHUB_PREVENT_COMMIT_RENDER != 'yes' -%}
     - git config user.email "qhub@quansight.com"
     - git config user.name "gitlab ci"
     - git add .
     - git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin "{{ cookiecutter.ci_cd.branch }}")
+{% endif %}
   only:
     refs:
       - "{{ cookiecutter.ci_cd.branch }}"

--- a/qhub/utils.py
+++ b/qhub/utils.py
@@ -36,7 +36,7 @@ if QHUB_GH_BRANCH:
     pip_install_qhub = (
         f"pip install https://github.com/Quansight/qhub/archive/{QHUB_GH_BRANCH}.zip"
     )
-
+QHUB_PREVENT_COMMIT_RENDER = os.environ.get("QHUB_PREVENT_COMMIT_RENDER","no")
 
 # Regex for suitable project names
 namestr_regex = r"^[A-Za-z][A-Za-z\-_]*[A-Za-z]$"


### PR DESCRIPTION
Combined with https://github.com/Quansight/qhub/pull/720 this enables deployment of QHub with gitops in such a way that secrets are not committed back to the repository.
