### PR TITLE
WIP: Clearml override

### DIFF
--- a/docs/source/admin_guide/clearml.md
+++ b/docs/source/admin_guide/clearml.md
@@ -36,6 +36,22 @@ google_cloud_platform:
         app: clearml
 ```
 
+## Clearml configuration overrides
+
+You can override your configuration without having to modify the helm files directly. The extra variable `overrides` makes this possible by changing the default values for the clearml helm chart according to the settings presented on your qhub-config.yaml file.
+
+For example, if you just want to override the node selector used for the agent you could use the following:
+
+```yaml
+prefect:
+ enabled: true
+ overrides:
+     agentServices:
+       NodeSelector:
+         app: "clearml_agent"
+```
+
+
 ## Accessing the server
 
 Users can access the ClearML server at: `app.clearml.your-qhub-domain.com`

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -80,7 +80,7 @@ class Monitoring(Base):
 class ClearML(Base):
     enabled: bool
     enable_forward_auth: typing.Optional[bool]
-
+    overrides: typing.Optional[typing.Dict]
 
 # ============== Prefect =============
 

--- a/qhub/template/cookiecutter.json
+++ b/qhub/template/cookiecutter.json
@@ -19,6 +19,7 @@
     },
     "clearml": {
         "enabled": null,
+        "overrides": null,
         "enable_forward_auth": null
     },
     "prefect": {

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
@@ -397,6 +397,13 @@ module "clearml" {
   namespace    = var.environment
   external-url = var.endpoint
   tls          = module.qhub.tls
+
+  {% if cookiecutter.clearml.overrides is defined %}
+  overrides            = [<<EOT
+{{ cookiecutter.clearml.overrides|yamlify -}}
+    EOT
+    ]
+  {% endif %}
 {% if cookiecutter.clearml.enable_forward_auth is defined -%}
   enable-forward-auth = {{ cookiecutter.clearml.enable_forward_auth | default(false,true) | jsonify }}
 {% endif -%}

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/kubernetes.tf
@@ -421,6 +421,7 @@ module "forwardauth" {
   namespace    = var.environment
   external-url = var.endpoint
 
+  node-group = local.node_groups.general
   jh-client-id      = local.forwardauth-keycloak-client-id
   jh-client-secret  = random_password.forwardauth-jhsecret.result
   callback-url-path = local.forwardauth-callback-url-path

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/forwardauth/main.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/forwardauth/main.tf
@@ -44,7 +44,21 @@ resource "kubernetes_deployment" "forwardauth-deployment" {
       }
 
       spec {
-
+        affinity {
+          node_affinity {
+            required_during_scheduling_ignored_during_execution {
+              node_selector_term {
+                match_expressions {
+                  key      = var.node-group.key
+                  operator = "In"
+                  values = [
+                    var.node-group.value
+                  ]
+                }
+              }
+            }
+          }
+        }
         container {
           # image = "thomseddon/traefik-forward-auth:2.2.0"
           # Use PR #159 https://github.com/thomseddon/traefik-forward-auth/pull/159

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/forwardauth/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/forwardauth/variables.tf
@@ -22,3 +22,11 @@ variable "callback-url-path" {
   description = "Path of Callback URL"
   type        = string
 }
+
+variable "node-group" {
+  description = "Node key value pair for bound general resources"
+  type = object({
+    key   = string
+    value = string
+  })
+}

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/clearml/chart/values.yaml
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/clearml/chart/values.yaml
@@ -226,6 +226,8 @@ redis: # configuration from https://github.com/bitnami/charts/blob/master/bitnam
   master:
     name: "{{ .Release.Name }}-redis-master"
     port: 6379
+    nodeSelector:
+      app: "clearml"
     persistence:
       enabled: true
       accessModes:
@@ -240,6 +242,8 @@ mongodb: # configuration from https://github.com/bitnami/charts/blob/master/bitn
     registry: docker.io
     repository: bitnami/mongodb
     tag: 3.6.21-debian-9-r71
+  nodeSelector:
+    app: "clearml"
   architecture: standalone
   auth:
     enabled: false

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/clearml/main.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/clearml/main.tf
@@ -53,4 +53,20 @@ resource "helm_release" "clearml" {
     }
   }
 
+  dynamic "set" {
+    for_each = var.node_selector
+    content {
+      name  = "mongodb.nodeSelector.${set.key}"
+      value = set.value
+    }
+  }
+
+  dynamic "set" {
+    for_each = var.node_selector
+    content {
+      name  = "redis.master.nodeSelector.${set.key}"
+      value = set.value
+    }
+  }
+
 }

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/clearml/main.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/clearml/main.tf
@@ -3,7 +3,9 @@ resource "helm_release" "clearml" {
   namespace         = var.namespace
   chart             = "${path.module}/chart"
   dependency_update = true
-  values            = [file("${path.module}/chart/values.yaml")]
+  values = concat([
+  file("${path.module}/chart/values.yaml")], var.overrides)
+
 
   dynamic "set" {
     for_each = var.node_selector

--- a/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/clearml/variables.tf
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/infrastructure/modules/kubernetes/services/clearml/variables.tf
@@ -30,3 +30,9 @@ variable "enable-forward-auth" {
   type    = bool
   default = true
 }
+
+variable "overrides" {
+  description = "Clearml helm chart list of overrides"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
This allows the clearml helm chart values to be over written via the qhub config yaml. Myself and @viniciusdc have not yet tested this. We are making use of this work in combination with #984 to target clearml pods to node pools for more efficient resource usage.