### PR TITLE
Fix Jupyterlab docker build

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -25,8 +25,6 @@ jobs:
   jupyterlab:
     name: 'Build Docker Images'
     runs-on: ubuntu-latest
-    env:
-      CONTEXT_PATH: "./qhub/template/{{ cookiecutter.repo_directory }}/image"
     strategy:
       matrix:
         dockerfile:
@@ -79,8 +77,8 @@ jobs:
       - name: Build docker
         uses: docker/build-push-action@v2
         with:
-          context: ${{ env.CONTEXT_PATH }}
-          file: "${{ env.CONTEXT_PATH }}/Dockerfile.${{ matrix.dockerfile }}"
+          context: "./qhub/template/{{ '{{ cookiecutter.repo_directory }}' }}/image"
+          file: "./qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.${{ matrix.dockerfile }}"
           tags: |
             ${{ steps.meta.outputs.tags }}
             ghcr.io/${{ steps.meta.outputs.tags }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -79,13 +79,13 @@ jobs:
           cd ./qhub/template
           ln -s ./\{\{\ cookiecutter.repo_directory\ \}\} cookiecutter
           sudo apt-get install tree
-          tree ./cookiecutter
+          tree ./cookiecutter/image
 
       - name: Build docker
         uses: docker/build-push-action@v2
         with:
           context: ./qhub/template/cookiecutter/image
-          file: "./qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.${{ matrix.dockerfile }}"
+          file: "./qhub/template/cookiecutter/image/Dockerfile.${{ matrix.dockerfile }}"
           tags: |
             ${{ steps.meta.outputs.tags }}
             ghcr.io/${{ steps.meta.outputs.tags }}
@@ -96,6 +96,6 @@ jobs:
       - name: Lint Dockerfiles
         uses: jbergstroem/hadolint-gh-action@v1
         with:
-          dockerfile: ./qhub/template/\{\{\ cookiecutter.repo_directory\ \}\}/image/Dockerfile.${{ matrix.dockerfile }}
+          dockerfile: ./qhub/template/cookiecutter/image/Dockerfile.${{ matrix.dockerfile }}
           output_format: tty
           error_level: 0

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Build docker
         uses: docker/build-push-action@v2
         with:
-          context: "./qhub/template/{{ '{{ cookiecutter.repo_directory }}' }}/image"
+          context: "./qhub/template/*/image"
           file: "./qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.${{ matrix.dockerfile }}"
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -74,17 +74,17 @@ jobs:
             type=ref,event=tag
             type=sha
 
-      - name: Check current dir tree
+      - name: Add symlink to cookiecutter dir and tree
         run: |
+          cd ./qhub/template
+          ln -s ./\{\{\ cookiecutter.repo_directory\ \}\} cookiecutter
           sudo apt-get install tree
-          tree ./qhub
-          ls -la ./qhub/template/*/image
-          echo "$GITHUB_REF"
+          tree ./cookiecutter
 
       - name: Build docker
         uses: docker/build-push-action@v2
         with:
-          context: ./qhub/template/*/image
+          context: ./qhub/template/cookiecutter/image
           file: "./qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.${{ matrix.dockerfile }}"
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Build docker
         uses: docker/build-push-action@v2
         with:
-          context: "./qhub/template/{{ cookiecutter.repo_directory }}/image"
+          context: ./qhub/template/\{\{\ cookiecutter.repo_directory\ \}\}/image
           file: "./qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.${{ matrix.dockerfile }}"
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -74,10 +74,17 @@ jobs:
             type=ref,event=tag
             type=sha
 
+      - name: Check current dir tree
+        run: |
+          sudo apt-get install tree
+          tree ./qhub
+          ls -la ./qhub/template/*
+          echo "$GITHUB_REF"
+
       - name: Build docker
         uses: docker/build-push-action@v2
         with:
-          context: r"""./qhub/template/{{ cookiecutter.repo_directory }}/image"""
+          context: ./qhub/template/{{ cookiecutter.repo_directory }}/image
           file: "./qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.${{ matrix.dockerfile }}"
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -79,8 +79,8 @@ jobs:
       - name: Build docker
         uses: docker/build-push-action@v2
         with:
-          context: "$CONTEXT_PATH"
-          file: "$CONTEXT_PATH/Dockerfile.${{ matrix.dockerfile }}"
+          context: ${{ env.CONTEXT_PATH }}
+          file: "${{ env.CONTEXT_PATH }}/Dockerfile.${{ matrix.dockerfile }}"
           tags: |
             ${{ steps.meta.outputs.tags }}
             ghcr.io/${{ steps.meta.outputs.tags }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -78,13 +78,13 @@ jobs:
         run: |
           sudo apt-get install tree
           tree ./qhub
-          ls -la ./qhub/template/*
+          ls -la ./qhub/template/*/image
           echo "$GITHUB_REF"
 
       - name: Build docker
         uses: docker/build-push-action@v2
         with:
-          context: ./qhub/template/{{ cookiecutter.repo_directory }}/image
+          context: ./qhub/template/*/image
           file: "./qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.${{ matrix.dockerfile }}"
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Build docker
         uses: docker/build-push-action@v2
         with:
-          context: "./qhub/template/*/image"
+          context: ./qhub/template/"{{ cookiecutter.repo_directory }}"/image
           file: "./qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.${{ matrix.dockerfile }}"
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Build docker
         uses: docker/build-push-action@v2
         with:
-          context: ./qhub/template/\{\{\ cookiecutter.repo_directory\ \}\}/image
+          context: "./qhub/template/{{ cookiecutter.repo_directory }}/image"
           file: "./qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.${{ matrix.dockerfile }}"
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Build docker
         uses: docker/build-push-action@v2
         with:
-          context: ./qhub/template/"{{ cookiecutter.repo_directory }}"/image
+          context: r"""./qhub/template/{{ cookiecutter.repo_directory }}/image"""
           file: "./qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.${{ matrix.dockerfile }}"
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -75,9 +75,9 @@ jobs:
             type=sha
 
       - name: Build docker
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v2.7
         with:
-          context: ./qhub/template/{{ cookiecutter.repo_directory }}/image
+          context: "./qhub/template/{{ cookiecutter.repo_directory }}/image"
           file: "./qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.${{ matrix.dockerfile }}"
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Build docker
         uses: docker/build-push-action@v2
         with:
-          context: "./qhub/template/{{ cookiecutter.repo_directory }}/image"
+          context: ./qhub/template/{{ cookiecutter.repo_directory }}/image
           file: "./qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.${{ matrix.dockerfile }}"
           tags: |
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -25,6 +25,8 @@ jobs:
   jupyterlab:
     name: 'Build Docker Images'
     runs-on: ubuntu-latest
+    env:
+      CONTEXT_PATH: "./qhub/template/{{ cookiecutter.repo_directory }}/image"
     strategy:
       matrix:
         dockerfile:
@@ -75,10 +77,10 @@ jobs:
             type=sha
 
       - name: Build docker
-        uses: docker/build-push-action@v2.7
+        uses: docker/build-push-action@v2
         with:
-          context: "./qhub/template/{{ cookiecutter.repo_directory }}/image"
-          file: "./qhub/template/{{ cookiecutter.repo_directory }}/image/Dockerfile.${{ matrix.dockerfile }}"
+          context: "$CONTEXT_PATH"
+          file: "$CONTEXT_PATH/Dockerfile.${{ matrix.dockerfile }}"
           tags: |
             ${{ steps.meta.outputs.tags }}
             ghcr.io/${{ steps.meta.outputs.tags }}

--- a/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterlab/postBuild
+++ b/qhub/template/{{ cookiecutter.repo_directory }}/image/jupyterlab/postBuild
@@ -16,8 +16,8 @@ cp /opt/jupyterlab/overrides.json /opt/conda/share/jupyter/lab/settings
 mkdir -p /opt/code_server
 cd /opt/code_server
 # Fetch the snapshot of https://code-server.dev/install.sh as of the time of writing
-curl -fsSL https://raw.githubusercontent.com/cdr/code-server/003dc0feeb5d437be1d6a4565fec7808b5aac69b/install.sh > install.sh
-expected_sum=4f66ead4b4ed2be7c746f1eaf6672f3e0cddad66924d9b6c513d108d68a0127c
+curl -fsSL https://raw.githubusercontent.com/coder/code-server/ec3d9974b3494e6055c8e65e1fb0e4bc665429a7/install.sh > install.sh
+expected_sum=4e1199a09f0777580aa2d8651f620d984ab99a45121cbd154c300a0280de751d
 
 if [[ ! $(sha256sum install.sh) == "${expected_sum}  install.sh" ]];then
     echo Unexpected hash from code-server install script


### PR DESCRIPTION
Fixes #1000 

On December 16th [code-server repo updated their `install.sh` file](https://github.com/coder/code-server/blob/ec3d9974b3494e6055c8e65e1fb0e4bc665429a7/install.sh), and updated their download URLs, causing the `postbuild` phase for the Jupyterlab image to fail. This PR updates the download URL for their installer.

Also, on January 18th our docker build/push action got [a new release](https://github.com/docker/build-push-action/releases/tag/v2.8.0) including support for [Handlebars](https://handlebarsjs.com/guide/), which conflicted with our main path for template images: `./qhub/templates/{{ cookiecutter.repo_directory }}`, as they seem to have added some kind of parser for the handlers that broke our workflow.

## Changes:

- Updates the snapshot URL for [code-server bash installer ](https://github.com/Quansight/qhub/blob/a44e759f136322010f74562a4ba5f1d5e55821ef/qhub/template/%7B%7B%20cookiecutter.repo_directory%20%7D%7D/image/jupyterlab/postBuild#L19)
- Add symlink for `./qhub/templates/{{ cookiecutter.repo_directory }} --> ./qhub/templates/cookiecutter`, and `tree`inspection over the symlink dir.


## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [ ] Yes
- [x] No
