### PR TITLE
Fix issue with traefik issueing certificates with letsencrypt acme

### DIFF
--- a/docs/source/admin_guide/index.md
+++ b/docs/source/admin_guide/index.md
@@ -15,6 +15,7 @@ jupyterhub.md
 keycloak.md
 clearml.md
 prefect.md
+traefik.md
 custom-helm-charts.md
 faq.md
 ```

--- a/docs/source/admin_guide/traefik.md
+++ b/docs/source/admin_guide/traefik.md
@@ -1,15 +1,15 @@
 # Traefik
 
-## Custom TLS Certificate
+## Custom TLS certificate
 
-### Creating the Certificate
+### Creating the certificate
 
-[lego](https://go-acme.github.io/lego/installation/) is a command line
+[Lego](https://go-acme.github.io/lego/installation/) is a command line
 tool for provisioning certificates for a domain. If you are trying to
 install QHub within an enterprise you may need to contact someone in
-IT to create the certificate and keypair for you. Ensure that this
+IT to create the certificate and key-pair for you. Ensure that this
 certificate has all of the domains that QHub is running on. Lego
-supports [multiple dns
+supports [multiple DNS
 providers](https://go-acme.github.io/lego/dns/). For this example we
 will assume Cloudflare as your DNS provider.
 
@@ -28,7 +28,7 @@ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3
   -nodes
 ```
 
-### Adding Certificate to kubernetes cluster as a secret
+### Adding certificate to kubernetes cluster as a secret
 
 You can name the certificate anything you would like
 `qhub-domain-certificate` is only an example.
@@ -39,7 +39,7 @@ kubectl create secret tls qhub-domain-certificate -n dev \
   --key=key.pem
 ```
 
-### Using Custom Certificate in qhub-config.yaml
+### Using custom certificate in qhub-config.yaml
 
 Once you have followed these steps make sure to modify the
 configuration to use the new certificate.

--- a/docs/source/admin_guide/traefik.md
+++ b/docs/source/admin_guide/traefik.md
@@ -1,0 +1,51 @@
+# Traefik
+
+## Custom TLS Certificate
+
+### Creating the Certificate
+
+[lego](https://go-acme.github.io/lego/installation/) is a command line
+tool for provisioning certificates for a domain. If you are trying to
+install QHub within an enterprise you may need to contact someone in
+IT to create the certificate and keypair for you. Ensure that this
+certificate has all of the domains that QHub is running on. Lego
+supports [multiple dns
+providers](https://go-acme.github.io/lego/dns/). For this example we
+will assume Cloudflare as your DNS provider.
+
+```shell
+export CLOUDFLARE_DNS_API_TOKEN=1234567890abcdefghijklmnopqrstuvwxyz
+lego --email myemail@example.com --dns cloudflare --domains my.example.org run
+```
+
+Or alternatively for testing you can create a self-signed
+certificate. This should only be used for testing.
+
+```shell
+export QHUB_DOMAIN=github-actions.qhub.dev
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 \
+  -subj "/C=US/ST=Oregon/L=Portland/O=Quansight/OU=Org/CN=$QHUB_DOMAIN" \
+  -nodes
+```
+
+### Adding Certificate to kubernetes cluster as a secret
+
+You can name the certificate anything you would like
+`qhub-domain-certificate` is only an example.
+
+```
+kubectl create secret tls qhub-domain-certificate -n dev \
+  --cert=cert.pem \
+  --key=key.pem
+```
+
+### Using Custom Certificate in qhub-config.yaml
+
+Once you have followed these steps make sure to modify the
+configuration to use the new certificate.
+
+```
+certificate:
+  type: existing
+  secret_name: qhub-domain-certificate
+```

--- a/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
@@ -237,12 +237,19 @@ resource "kubernetes_deployment" "main" {
             # working. Fetch logs of the pod.
             "--log.level=${var.loglevel}",
             ], var.enable-certificates ? [
-            "--entrypoints.websecure.http.tls.certResolver=letencrypt",
+            "--entrypoints.websecure.http.tls.certResolver=letsencrypt",
             "--certificatesresolvers.letsencrypt.acme.tlschallenge",
             "--certificatesresolvers.letsencrypt.acme.email=${var.acme-email}",
             "--certificatesresolvers.letsencrypt.acme.storage=acme.json",
             "--certificatesresolvers.letsencrypt.acme.caserver=${var.acme-server}",
-          ] : [])
+          ] : [
+            # ideally we could write "--entrypoints.websecure.http.tls={}"
+            # but this doesn't seem to work?
+            # since all we want to do is trigger traefik to generate a certificate
+            # the downside of specifying this is you will see error messages
+            # in the traefik logs like "... uses a non-existent resolver: default"
+            "--entrypoints.websecure.http.tls.certResolver=default",
+          ])
 
           port {
             name           = "http"
@@ -317,7 +324,7 @@ resource "kubernetes_manifest" "tlsstore_default" {
     "apiVersion" = "traefik.containo.us/v1alpha1"
     "kind" = "TLSStore"
     "metadata" = {
-      "name" = "${var.name}-tlsstore"
+      "name" = "default"
       "namespace" = var.namespace
     }
     "spec" = {

--- a/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
@@ -236,8 +236,9 @@ resource "kubernetes_deployment" "main" {
             # Enable debug logging. Useful to work out why something might not be
             # working. Fetch logs of the pod.
             "--log.level=${var.loglevel}",
-            ], var.enable-certificates ? [
+          ], var.enable-certificates ? [
             "--entrypoints.websecure.http.tls.certResolver=letsencrypt",
+            "--entrypoints.minio.http.tls.certResolver=letsencrypt",
             "--certificatesresolvers.letsencrypt.acme.tlschallenge",
             "--certificatesresolvers.letsencrypt.acme.email=${var.acme-email}",
             "--certificatesresolvers.letsencrypt.acme.storage=acme.json",
@@ -249,6 +250,7 @@ resource "kubernetes_deployment" "main" {
             # the downside of specifying this is you will see error messages
             # in the traefik logs like "... uses a non-existent resolver: default"
             "--entrypoints.websecure.http.tls.certResolver=default",
+            "--entrypoints.minio.http.tls.certResolver=default",
           ])
 
           port {

--- a/qhub/template/stages/05-kubernetes-keycloak/modules/kubernetes/keycloak-helm/main.tf
+++ b/qhub/template/stages/05-kubernetes-keycloak/modules/kubernetes/keycloak-helm/main.tf
@@ -58,7 +58,6 @@ resource "kubernetes_manifest" "keycloak-http" {
           ]
         }
       ]
-      tls = {}
     }
   }
 }

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/forwardauth/main.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/forwardauth/main.tf
@@ -188,7 +188,6 @@ resource "kubernetes_manifest" "forwardauth-ingressroute" {
           ]
         }
       ]
-      tls = {}
     }
   }
 }

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/clearml/ingress.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/clearml/ingress.tf
@@ -40,7 +40,6 @@ resource "kubernetes_manifest" "clearml-app" {
           ]
         }
       ]
-      tls = {}
     }
   }
 }
@@ -69,7 +68,6 @@ resource "kubernetes_manifest" "clearml-files" {
           ]
         }
       ]
-      tls = {}
     }
   }
 }
@@ -98,7 +96,6 @@ resource "kubernetes_manifest" "clearml-api" {
           ]
         }
       ]
-      tls = {}
     }
   }
 }

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/server.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/server.tf
@@ -149,7 +149,6 @@ resource "kubernetes_manifest" "jupyterhub" {
           ]
         }
       ]
-      tls = {}
     }
   }
 }

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/dask-gateway/main.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/dask-gateway/main.tf
@@ -50,7 +50,6 @@ resource "kubernetes_manifest" "dask-gateway" {
           ]
         }
       ]
-      tls = {}
     }
   }
 }

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/main.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/main.tf
@@ -133,7 +133,6 @@ resource "kubernetes_manifest" "jupyterhub" {
           ]
         }
       ]
-      tls = {}
     }
   }
 }

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/minio/ingress.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/minio/ingress.tf
@@ -21,7 +21,6 @@ resource "kubernetes_manifest" "minio-api" {
           ]
         }
       ]
-      tls = {}
     }
   }
 }

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/monitoring/main.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/monitoring/main.tf
@@ -142,7 +142,6 @@ resource "kubernetes_manifest" "grafana-ingress-route" {
           ]
         }
       ]
-      tls = {}
     }
   }
 }

--- a/tests/vale/styles/vocab.txt
+++ b/tests/vale/styles/vocab.txt
@@ -25,6 +25,8 @@ cpu
 cpus
 cuda
 cudatoolkit
+dns
+Lego
 dask
 Dask
 Daskgpus


### PR DESCRIPTION
The core of the issue was that for entrypoints a default certResolver
was not being specified. Additionally had to read some docs within
traefik https://doc.traefik.io/traefik/routing/entrypoints/#tls that
state that is a `tls = {}` section is specified within the crd
ingressroute the tls configuration is overwritten.

```
If a TLS section (i.e. any of its fields) is user-defined, then the
default configuration does not apply at all.
```

Fixes #1015 

## Changes:

- changes related to traefik ingress

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

Tested locally using minikube and using digitalocean

### Requires testing

- [X] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [X] No
