### PR TITLE
Increase timeout/attempts for keycloak check

### DIFF
--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -634,8 +634,8 @@ def check_06_kubernetes_keycloak_configuration(stage_outputs, config):
         client_id,
         qhub_realm,
         verify=False,
-        num_attempts=3,
-        timeout=5,
+        num_attempts=5,
+        timeout=10,
     ):
         for i in range(num_attempts):
             try:


### PR DESCRIPTION
Fixes #1022

Increasing the number of attempts and timeout for checking if the keycloak server is in a running state might solve the flacky tests.

## Changes:

- Increase number of attempts and timeout condition for requesting access to keycloak admin URI

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [ ] Yes
- [x] No