### PR TITLE
Fixing cdsdashboard conda environments being shown

### DIFF
--- a/qhub/template/stages/07-kubernetes-services/jupyterhub.tf
+++ b/qhub/template/stages/07-kubernetes-services/jupyterhub.tf
@@ -92,6 +92,7 @@ module "jupyterhub" {
 
   conda-store-pvc = module.conda-store-nfs-mount.persistent_volume_claim.name
   conda-store-mount = "/home/conda"
+  conda-store-environments = var.conda-store-environments
 
   extra-mounts = {
     "/etc/dask"    = {

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/02-spawner.py
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/02-spawner.py
@@ -8,6 +8,7 @@ from kubespawner import KubeSpawner
 import z2jh
 
 cdsdashboards = z2jh.get_config("custom.cdsdashboards")
+conda_store_environments = z2jh.get_config("custom.environments")
 
 if cdsdashboards["enabled"]:
     from cdsdashboards.hubextension.spawners.variablekube import VariableKubeSpawner
@@ -31,9 +32,7 @@ if cdsdashboards["enabled"]:
     c.CDSDashboardsConfig.spawn_default_options = False
 
     c.CDSDashboardsConfig.conda_envs = [
-        # {%- for key in cookiecutter.environments %}
-        #     "{{ cookiecutter.environments[key].name }}",
-        # {%- endfor %}
+        environment['name'] for _, environment in conda_store_environments.items()
     ]
 else:
     c.JupyterHub.allow_named_servers = False

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/main.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/main.tf
@@ -31,6 +31,7 @@ resource "helm_release" "jupyterhub" {
         conda-store-pvc   = var.conda-store-pvc
         conda-store-mount = var.conda-store-mount
         extra-mounts      = var.extra-mounts
+        environments      = var.conda-store-environments
       }
 
       hub = {

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/variables.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/variables.tf
@@ -110,3 +110,9 @@ variable "cdsdashboards" {
     cds_hide_user_dashboard_servers = false
   }
 }
+
+variable "conda-store-environments" {
+  description = "conda environments from conda-store in filesystem namespace"
+  type        = map(any)
+  default     = {}
+}


### PR DESCRIPTION
This is a short term fix for conda-store environments being shown in
cdsdashboards. Longer term we will need to consult the conda-store
rest api or filesystem for available environments (for 0.4.x release).

Fixes #1019

## Changes:

- added environments from `qhub-config.yaml` to cdsdashboards list.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [X] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [X] No
