### PR TITLE
Removing cookiecutter from setup.cfg requirements

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,17 +41,18 @@
         pkgs.minikube
         pkgs.k9s
       ];
-    in {
+    in rec {
       defaultApp.x86_64-linux = pythonPackages.buildPythonPackage {
         pname = "qhub";
         version = "latest";
+        format = "pyproject";
 
         src = ./.;
 
         propagatedBuildInputs = propagatedDependencies;
 
         patchPhase = ''
-          substituteInPlace setup.py \
+          substituteInPlace setup.cfg \
             --replace "azure-identity==1.6.1" "azure-identity" \
             --replace "azure-mgmt-containerservice==16.2.0" "azure-mgmt-containerservice"
         '';
@@ -61,7 +62,7 @@
 
       devShell.x86_64-linux =
         pkgs.mkShell {
-          buildInputs = propagatedDependencies ++ devDependencies;
+          buildInputs = propagatedDependencies ++ devDependencies ++ [ defaultApp.x86_64-linux ];
         };
     };
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ project_urls =
 zip_safe = False
 include_package_data = True
 install_requires =
-    cookiecutter==1.7.2
     ruamel.yaml
     cloudflare
     auth0-python


### PR DESCRIPTION
Simple PR that removes cookiecutter from setup.cfg requirements. Also update flake.nix to allow for qhub to still build.