### PR TITLE
Fix input variable support for multiple types

### DIFF
--- a/qhub/template/stages/06-kubernetes-keycloak-configuration/variables.tf
+++ b/qhub/template/stages/06-kubernetes-keycloak-configuration/variables.tf
@@ -15,4 +15,8 @@ variable "authentication" {
     type = string
     config = map(string)
   })
+  default = {
+    config = {}
+    type = ""
+  }
 }

--- a/qhub/template/stages/06-kubernetes-keycloak-configuration/variables.tf
+++ b/qhub/template/stages/06-kubernetes-keycloak-configuration/variables.tf
@@ -11,5 +11,8 @@ variable "keycloak_groups" {
 
 variable "authentication" {
   description = "Authentication configuration for keycloak"
-  type = map
+  type = object({
+    type = string
+    config = map(string)
+  })
 }

--- a/qhub/template/stages/06-kubernetes-keycloak-configuration/variables.tf
+++ b/qhub/template/stages/06-kubernetes-keycloak-configuration/variables.tf
@@ -11,12 +11,5 @@ variable "keycloak_groups" {
 
 variable "authentication" {
   description = "Authentication configuration for keycloak"
-  type = object({
-    type = string
-    config = map(string)
-  })
-  default = {
-    config = {}
-    type = ""
-  }
+  type = any
 }


### PR DESCRIPTION
Fixes #1028 

The current `map` type for `authentication` lead to terraform to decide the type of variables it will be receiving from the input. But, when using extra forms of authentication like `Github, Auth0` the extra field `authentication.config` has a dict type structure, and `authentication.type` has an str type structure which lead to the following error when deploying the stage:

```
... map elements must have the same type.
```
edit.: Opted for variable type: `any` as using `object` structure obliges the variable input to have the same structure as specified which conflicts with the authentication modes of qhub (some does not include the `config` key)

## Changes:

- Update variable `authentication` type to include multiple value types.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [x] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

## Further comments (optional)

Already tested on minikube local deployment with Auth0 config.