### PR TITLE
Fix Black/Flake8 problems [WIP]

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,12 +37,12 @@ jobs:
       - name: Black Formatting
         run: |
           black --version
-          black qhub --diff
-          black --check qhub
+          black qhub --diff --exclude /qhub/template/
+          black --check qhub --exclude /qhub/template/
       - name: Flake8 Formatting
         run: |
           flake8 --version
-          flake8
+          flake8 qhub --exclude ./qhub/template/
       - name: Test QHub
         run: |
           pytest --version

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,12 +37,12 @@ jobs:
       - name: Black Formatting
         run: |
           black --version
-          black qhub --diff --exclude /qhub/template/
-          black --check qhub --exclude /qhub/template/
+          black qhub --diff
+          black --check qhub
       - name: Flake8 Formatting
         run: |
           flake8 --version
-          flake8 qhub --exclude ./qhub/template/
+          flake8
       - name: Test QHub
         run: |
           pytest --version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,12 @@ repos:
     rev: 20.8b1
     hooks:
     -   id: black
+        exclude: '/qhub/template/'
   - repo: https://github.com/pycqa/flake8
     rev: 3.8.4
     hooks:
     -   id: flake8
-        exclude: 'qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/config/conda_store_config.py'
+        exclude: 'qhub/template'
         args: [
           "--builtins=c"
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 line-length = 88
 target-version = ['py36', 'py37', 'py38']
-exclude = '/\{\{ cookiecutter.repo_directory \}\}/'
+exclude = '/qhub/template/'
 
 [tool.setuptools_scm]
 write_to = "qhub/_version.py"


### PR DESCRIPTION
Attempt to solve black problems seen on GitHub Actions but not CI.

We used to exclude cookie-cutter template folder from black, but this has obviously been replaced by template/stages which has a few random python files (e.g. jupyterhub_config.py).

These weren't safe to run through black before because they were jinja2 templates. It would be safe now, but I don't think it really makes sense to run black/flake8 on the template folder, so will submit a PR shortly.

## Changes:

- Exclude `qhub/template` from flake8 and black in both pre-commit and pyproject.toml

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [ ] Yes
- [x] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

