### PR TITLE
prevent_deploy flag for safeguarding upgrades

### DIFF
--- a/docs/source/admin_guide/upgrade.md
+++ b/docs/source/admin_guide/upgrade.md
@@ -42,6 +42,10 @@ If you are deploying QHub from your local machine (not using CI/CD) then you wil
 qhub deploy -m qhub-config.yaml
 ```
 
+At this point you may see an error message saying that deployment is prevented due to the `prevent_deploy` setting in your YAML file. This is a safeguard to ensure that you only proceed if you are aware of possible breaking changes in the current upgrade.
+
+For example, we may be aware that you will lose data due to this upgrade, so need to note a specific upgrade process to keep your data safe. Always check the release notes of the release in this case and get in touch with us if you need assistance. For example, you may find that your existing cluster is intentionally deleted so that a new replacement can be deployed instead, in which case your data must be backed up so it can be restored after the upgrade.
+
 ### CI/CD: render and commit to git
 
 For CI/CD (GitHub/GitLab) workflows, then as well as generating the updated `qhub-config.yaml` files as above, you will also need to regenerate the workflow files based on the latest `qhub` version's templates.

--- a/qhub/cli/deploy.py
+++ b/qhub/cli/deploy.py
@@ -40,11 +40,6 @@ def create_deploy_subcommand(subparser):
         action="store_true",
         help="Disable auto-rendering in deploy stage",
     )
-    subparser.add_argument(
-        "--full-only",
-        action="store_true",
-        help="Only carry out one full pass instead of targeted sections (for development purposes)",
-    )
     subparser.set_defaults(func=handle_deploy)
 
 
@@ -68,5 +63,4 @@ def handle_deploy(args):
         args.dns_auto_provision,
         args.disable_prompt,
         args.skip_remote_state_provision,
-        args.full_only,
     )

--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -8,6 +8,7 @@ from subprocess import CalledProcessError
 from typing import Dict
 import tempfile
 import json
+import textwrap
 
 from qhub.provider import terraform
 from qhub.utils import (
@@ -28,8 +29,25 @@ def deploy_configuration(
     dns_auto_provision,
     disable_prompt,
     skip_remote_state_provision,
-    full_only,
 ):
+    if config.get("prevent_deploy", False):
+        # Note if we used the Pydantic model properly, we might get that qhub_config.prevent_deploy always exists but defaults to False
+        raise ValueError(
+            textwrap.dedent(
+                """
+        Deployment prevented due to the prevent_deploy setting in your qhub-config.yaml file.
+        You could remove that field to deploy your QHub, but please do NOT do so without fully understanding why that value was set in the first place.
+
+        It may have been set during an upgrade of your qhub-config.yaml file because we do not believe it is safe to redeploy the new
+        version of QHub without having a full backup of your system ready to restore. It may be known that an in-situ upgrade is impossible
+        and that redeployment will tear down your existing infrastructure before creating an entirely new QHub without your old data.
+
+        PLEASE get in touch with Quansight at https://github.com/Quansight/qhub for assistance in proceeding.
+        Your data may be at risk without our guidance.
+        """
+            )
+        )
+
     logger.info(f'All qhub endpoints will be under https://{config["domain"]}')
 
     with timer(logger, "deploying QHub"):
@@ -40,7 +58,6 @@ def deploy_configuration(
                 dns_auto_provision,
                 disable_prompt,
                 skip_remote_state_provision,
-                full_only,
             )
         except CalledProcessError as e:
             logger.error(e.output)
@@ -806,14 +823,17 @@ def guided_install(
     dns_auto_provision,
     disable_prompt=False,
     skip_remote_state_provision=False,
-    full_only=False,
 ):
     # 01 Check Environment Variables
     check_cloud_credentials(config)
 
     stage_outputs = {}
     if config["provider"] != "local" and config["terraform_state"]["type"] == "remote":
-        provision_01_terraform_state(stage_outputs, config)
+        if skip_remote_state_provision:
+            print("Skipping remote state provision")
+        else:
+            provision_01_terraform_state(stage_outputs, config)
+
     provision_02_infrastructure(stage_outputs, config)
 
     with kubernetes_provider_context(

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -438,6 +438,9 @@ class Main(Base):
     clearml: typing.Optional[ClearML]
     extensions: typing.Optional[typing.List[QHubExtension]]
     jupyterhub: typing.Optional[JupyterHub]
+    prevent_deploy: bool = (
+        False  # Optional, but will be given default value if not present
+    )
 
     # If the qhub_version in the schema is old
     # we must tell the user to first run qhub upgrade
@@ -461,7 +464,7 @@ class Main(Base):
 
 
 def verify(config):
-    Main(**config)
+    return Main(**config)
 
 
 def is_version_accepted(v):

--- a/qhub/upgrade.py
+++ b/qhub/upgrade.py
@@ -327,6 +327,12 @@ class Upgrade_0_4_0(UpgradeStep):
             if "scope" in auth_config:
                 del auth_config["scope"]
 
+        # It is not safe to immediately redeploy without backing up data ready to restore data
+        # since a new cluster will be created for the new version.
+        # Setting the following flag will prevent deployment and display guidance to the user
+        # which they can override if they are happy they understand the situation.
+        config["prevent_deploy"] = True
+
         return config
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -22,4 +22,5 @@ def test_schema(setup_fixture):
         auth_provider=auth_provider,
         kubernetes_version=None,
     )
-    assert qhub.schema.verify(config) is None
+
+    qhub.schema.verify(config)


### PR DESCRIPTION
Also fix --skip-remote-state-provision and remove --full-only which is no longer used)

Fixes #1040 

## Changes:

Added a `prevent_default` field to the `qhub-config.yaml` that will be set after `qhub upgrade` to 0.4.0. This stops users blindly redeploying without understanding the full upgrade process.

Also
- Fixed `--skip-remote-state-provision` which was being ignored
- Removed `--full-only` flag which was no longer used

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [X] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [X] No

## Further comments (optional)

I have added general upgrade documentation but we also need to spell out the full upgrade process in release notes and/or docs.