### PR TITLE
Fixup adding support for security.keycloak.realm_display_name key

### DIFF
--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -603,11 +603,13 @@ def check_05_kubernetes_keycloak(stage_outputs, config):
 
 def provision_06_kubernetes_keycloak_configuration(stage_outputs, config, check=True):
     directory = "stages/06-kubernetes-keycloak-configuration"
+    realm_id = f"qhub-{config['project_name']}"
 
     stage_outputs[directory] = terraform.deploy(
         directory=directory,
         input_vars={
-            "realm": f"qhub-{config['project_name']}",
+            "realm": realm_id,
+            "realm_display_name": config['security']['keycloak'].get('realm_display_name', realm_id),
             "authentication": config["security"]["authentication"],
         },
     )

--- a/qhub/template/stages/06-kubernetes-keycloak-configuration/main.tf
+++ b/qhub/template/stages/06-kubernetes-keycloak-configuration/main.tf
@@ -1,7 +1,8 @@
 resource "keycloak_realm" "main" {
   provider = keycloak
 
-  realm = var.realm
+  realm        = var.realm
+  display_name = var.realm_display_name
 }
 
 

--- a/qhub/template/stages/06-kubernetes-keycloak-configuration/variables.tf
+++ b/qhub/template/stages/06-kubernetes-keycloak-configuration/variables.tf
@@ -3,6 +3,11 @@ variable "realm" {
   type        = string
 }
 
+variable "realm_display_name" {
+  description = "Keycloak realm display name for QHub"
+  type        = string
+}
+
 variable "keycloak_groups" {
   description = "Permission groups in keycloak used for granting access to services"
   type = set(string)


### PR DESCRIPTION
There was a bug in that we no longer suported the `security.keycloak.realm_display_name` .This is now supported.

