### PR TITLE
Fixup adding back jupyterhub overrides option

### DIFF
--- a/docs/source/installation/configuration.md
+++ b/docs/source/installation/configuration.md
@@ -788,6 +788,22 @@ QHub will refuse to deploy if it doesn't contain the same version as that of the
 
 Typically, you can upgrade the qhub-config.yaml file itself using the [`qhub upgrade` command](../admin_guide/upgrade.md). This will update image numbers, plus updating qhub_version to match the installed version of `qhub`, as well as any other bespoke changes required.
 
+## JupyterHub
+
+JupyterHub uses the [zero to jupyterhub helm
+chart](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/). This
+chart has many options that are not configured in the QHub default
+installation. You can override specific values in the
+[values.yaml](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/main/jupyterhub/values.yaml). `jupyterhub.overrides`
+is optional.
+
+```yaml
+jupyterhub:
+  overrides:
+    cull:
+      users: true
+```
+
 # Full configuration example
 
 ```yaml

--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -725,6 +725,9 @@ def provision_07_kubernetes_services(stage_outputs, config, check=True):
             "jupyterlab-image": split_docker_image_name(
                 config["default_images"]["jupyterlab"]
             ),
+            "jupyterhub-overrides": [
+                json.dumps(config.get("jupyterhub", {}).get("overrides", {}))
+            ],
             # dask-gateway
             "dask-gateway-image": split_docker_image_name(
                 config["default_images"]["dask_gateway"]

--- a/qhub/template/stages/07-kubernetes-services/jupyterhub.tf
+++ b/qhub/template/stages/07-kubernetes-services/jupyterhub.tf
@@ -26,6 +26,12 @@ variable "jupyterhub-image" {
   })
 }
 
+variable "jupyterhub-overrides" {
+  description = "Jupyterhub helm chart overrides"
+  type        = list(string)
+  default     = []
+}
+
 variable "jupyterhub-shared-storage" {
   description = "JupyterHub shared storage size [GB]"
   type        = string
@@ -85,6 +91,8 @@ module "jupyterhub" {
 
   external-url = var.endpoint
   realm_id = var.realm_id
+
+  overrides = var.jupyterhub-overrides
 
   home-pvc = module.jupyterhub-nfs-mount.persistent_volume_claim.name
 


### PR DESCRIPTION
Prior to #1003 there was the option `jupyterhub.overrides`. Here we
are adding back this option and ensuring that there is documentation
on the option.
