### PR TITLE
CI: Add layer caching for Docker images

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -46,6 +46,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -53,6 +54,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Quay Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           registry: quay.io

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -89,6 +89,8 @@ jobs:
             quay.io/${{ steps.meta.outputs.tags }}
           push: ${{ github.event_name != 'pull_request' }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Lint Dockerfiles
         uses: jbergstroem/hadolint-gh-action@v1


### PR DESCRIPTION
## Description

This PR:

- Adds layer caching for Docker images
- Adds an `if:` statement where a log-in step would be run only on pushes and workflow runs

## Results

|Image       |CI time (before)     |CI time (after)      |
|------------|---------------------|---------------------|
|Jupyterlab  |~10 minutes          |~30 seconds          |
|Jupyterhub  |~2 minutes 41 seconds|~2 minutes 14 seconds|
|Dask-worker |~3 minutes           |~2 minutes 27 seconds|
|Dask-gateway|~40 seconds          |~36 seconds          |

## Logs

- [CI before](https://github.com/Quansight/qhub/runs/5174291033?check_suite_focus=true)
- [CI after](https://github.com/Quansight/qhub/runs/5174357150?check_suite_focus=true)


