### PR TITLE
Auto create/destroy azure resource group

### DIFF
--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -296,6 +296,8 @@ def provision_02_infrastructure(stage_outputs, config, check=True):
                 "kubeconfig_filename": os.path.join(
                     tempfile.gettempdir(), "QHUB_KUBECONFIG"
                 ),
+                "resource_group_name" : f'{config["project_name"]}-{config["namespace"]}',
+                "node_resource_group_name" : f'{config["project_name"]}-{config["namespace"]}-node-resource-group',
             },
         )
     elif config["provider"] == "aws":

--- a/qhub/destroy.py
+++ b/qhub/destroy.py
@@ -178,6 +178,8 @@ def destroy_02_infrastructure(config):
                 "kubeconfig_filename": os.path.join(
                     tempfile.gettempdir(), "QHUB_KUBECONFIG"
                 ),
+                "resource_group_name" : f'{config["project_name"]}-{config["namespace"]}',
+                "node_resource_group_name" : f'{config["project_name"]}-{config["namespace"]}-node-resource-group',
             },
         )
     elif config["provider"] == "aws":

--- a/qhub/template/stages/02-infrastructure/azure/variables.tf
+++ b/qhub/template/stages/02-infrastructure/azure/variables.tf
@@ -32,3 +32,13 @@ variable "kubeconfig_filename" {
   type        = string
   default     = null
 }
+
+variable "resource_group_name" {
+  description = "Specifies the Resource Group where the Managed Kubernetes Cluster should exist"
+  type        = string
+}
+
+variable "node_resource_group_name" {
+  description = "The name of the Resource Group where the Kubernetes Nodes should exist"
+  type        = string
+}


### PR DESCRIPTION
Fixes #1041 

This adds the ability over Qhub to create the main resource group and includes its name (as well as the node resource group name) in the variables of deploy and destroy.

This might as well might help fix #1043, as it could be related to the aks cluster region not being in sync with the resource group region.

## Changes:

- Add `resource_group_name` and `node_resoruce_group_name` as variables over deploy and destroy
- Includes `azurerm_resource_group` resource during deployment 
- Add note informing that it's not possible assigning existing resource groups as node resource groups before deployment

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [x] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

## Further comments (optional)

Tested during v0.4.0 release resting process.