### PR TITLE
Reorganizing render, deploy, destroy to unify stages input_vars, tf_objects, checks, and state_imports

### DIFF
--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -1,72 +1,18 @@
-import socket
-import time
 import logging
 import os
-import sys
-import contextlib
-from subprocess import CalledProcessError
-from typing import Dict
 import tempfile
-import json
 import textwrap
-from urllib.parse import urlencode
+import subprocess
+from typing import Dict
+import contextlib
 
+from qhub.utils import modified_environ, check_cloud_credentials, timer
+from qhub.stages import checks, state_imports, input_vars
 from qhub.provider import terraform
-from qhub.utils import (
-    timer,
-    check_cloud_credentials,
-    modified_environ,
-    split_docker_image_name,
-)
 from qhub.provider.dns.cloudflare import update_record
 
 
 logger = logging.getLogger(__name__)
-
-# check and retry settings
-NUM_ATTEMPTS = 10
-TIMEOUT = 10  # seconds
-
-
-def deploy_configuration(
-    config,
-    dns_provider,
-    dns_auto_provision,
-    disable_prompt,
-    skip_remote_state_provision,
-):
-    if config.get("prevent_deploy", False):
-        # Note if we used the Pydantic model properly, we might get that qhub_config.prevent_deploy always exists but defaults to False
-        raise ValueError(
-            textwrap.dedent(
-                """
-        Deployment prevented due to the prevent_deploy setting in your qhub-config.yaml file.
-        You could remove that field to deploy your QHub, but please do NOT do so without fully understanding why that value was set in the first place.
-
-        It may have been set during an upgrade of your qhub-config.yaml file because we do not believe it is safe to redeploy the new
-        version of QHub without having a full backup of your system ready to restore. It may be known that an in-situ upgrade is impossible
-        and that redeployment will tear down your existing infrastructure before creating an entirely new QHub without your old data.
-
-        PLEASE get in touch with Quansight at https://github.com/Quansight/qhub for assistance in proceeding.
-        Your data may be at risk without our guidance.
-        """
-            )
-        )
-
-    logger.info(f'All qhub endpoints will be under https://{config["domain"]}')
-
-    with timer(logger, "deploying QHub"):
-        try:
-            guided_install(
-                config,
-                dns_provider,
-                dns_auto_provision,
-                disable_prompt,
-                skip_remote_state_provision,
-            )
-        except CalledProcessError as e:
-            logger.error(e.output)
-            raise e
 
 
 @contextlib.contextmanager
@@ -107,120 +53,17 @@ def keycloak_provider_context(keycloak_credentials: Dict[str, str]):
         yield
 
 
-def calculate_note_groups(config):
-    if config["provider"] == "aws":
-        return {
-            group: {"key": "eks.amazonaws.com/nodegroup", "value": group}
-            for group in ["general", "user", "worker"]
-        }
-    elif config["provider"] == "gcp":
-        return {
-            group: {"key": "cloud.google.com/gke-nodepool", "value": group}
-            for group in ["general", "user", "worker"]
-        }
-    elif config["provider"] == "azure":
-        return {
-            group: {"key": "azure-node-pool", "value": group}
-            for group in ["general", "user", "worker"]
-        }
-    elif config["provider"] == "do":
-        return {
-            group: {"key": "doks.digitalocean.com/node-pool", "value": group}
-            for group in ["general", "user", "worker"]
-        }
-    else:
-        return config["local"]["node_selectors"]
-
-
 def provision_01_terraform_state(stage_outputs, config):
     directory = "stages/01-terraform-state"
 
     if config["provider"] == "local":
         stage_outputs[directory] = {}
-    elif config["provider"] == "do":
-        stage_outputs[directory] = terraform.deploy(
-            terraform_import=True,
-            directory=os.path.join(directory, config["provider"]),
-            input_vars={
-                "name": config["project_name"],
-                "namespace": config["namespace"],
-                "region": config["digital_ocean"]["region"],
-            },
-            state_imports=[
-                (
-                    "module.terraform-state.module.spaces.digitalocean_spaces_bucket.main",
-                    f"{config['digital_ocean']['region']},{config['project_name']}-{config['namespace']}-terraform-state",
-                )
-            ],
-        )
-    elif config["provider"] == "gcp":
-        stage_outputs[directory] = terraform.deploy(
-            terraform_import=True,
-            directory=os.path.join(directory, config["provider"]),
-            input_vars={
-                "name": config["project_name"],
-                "namespace": config["namespace"],
-                "region": config["google_cloud_platform"]["region"],
-            },
-            state_imports=[
-                (
-                    "module.terraform-state.module.gcs.google_storage_bucket.static-site",
-                    f"{config['project_name']}-{config['namespace']}-terraform-state",
-                )
-            ],
-        )
-    elif config["provider"] == "azure":
-        subscription_id = os.environ["ARM_SUBSCRIPTION_ID"]
-        resource_group_name = f"{config['project_name']}-{config['namespace']}"
-        resource_group_name_safe = resource_group_name.replace("-", "")
-        resource_group_url = f"/subscriptions/{subscription_id}/resourceGroups/{config['project_name']}-{config['namespace']}"
-
-        stage_outputs[directory] = terraform.deploy(
-            terraform_import=True,
-            directory=os.path.join(directory, config["provider"]),
-            input_vars={
-                "name": config["project_name"],
-                "namespace": config["namespace"],
-                "region": config["azure"]["region"],
-                "storage_account_postfix": config["azure"]["storage_account_postfix"],
-            },
-            state_imports=[
-                (
-                    "module.terraform-state.azurerm_resource_group.terraform-resource-group",
-                    resource_group_url,
-                ),
-                (
-                    "module.terraform-state.azurerm_storage_account.terraform-storage-account",
-                    f"{resource_group_url}/providers/Microsoft.Storage/storageAccounts/{resource_group_name_safe}{config['azure']['storage_account_postfix']}",
-                ),
-                (
-                    "module.terraform-state.azurerm_storage_container.storage_container",
-                    f"https://{resource_group_name_safe}{config['azure']['storage_account_postfix']}.blob.core.windows.net/{resource_group_name}state",
-                ),
-            ],
-        )
-    elif config["provider"] == "aws":
-        stage_outputs[directory] = terraform.deploy(
-            terraform_import=True,
-            directory=os.path.join(directory, config["provider"]),
-            input_vars={
-                "name": config["project_name"],
-                "namespace": config["namespace"],
-            },
-            state_imports=[
-                (
-                    "module.terraform-state.aws_s3_bucket.terraform-state",
-                    f"{config['project_name']}-{config['namespace']}-terraform-state",
-                ),
-                (
-                    "module.terraform-state.aws_dynamodb_table.terraform-state-lock",
-                    f"{config['project_name']}-{config['namespace']}-terraform-state-lock",
-                ),
-            ],
-        )
     else:
-        raise NotImplementedError(
-            f'provider {config["provider"]} not implemented for directory={directory}'
+        stage_outputs[directory] = terraform.deploy(
+            terraform_import=True,
+            directory=os.path.join(directory, config["provider"]),
+            input_vars=input_vars.stage_01_terraform_state(stage_outputs, config),
+            state_imports=state_imports.stage_01_terraform_state(stage_outputs, config),
         )
 
 
@@ -241,128 +84,13 @@ def provision_02_infrastructure(stage_outputs, config, check=True):
     """
     directory = "stages/02-infrastructure"
 
-    if config["provider"] == "local":
-        stage_outputs[directory] = terraform.deploy(
-            os.path.join(directory, config["provider"]),
-            input_vars={"kube_context": config["local"].get("kube_context")},
-        )
-    elif config["provider"] == "do":
-        stage_outputs[directory] = terraform.deploy(
-            os.path.join(directory, config["provider"]),
-            input_vars={
-                "name": config["project_name"],
-                "environment": config["namespace"],
-                "region": config["digital_ocean"]["region"],
-                "kubernetes_version": config["digital_ocean"]["kubernetes_version"],
-                "node_groups": config["digital_ocean"]["node_groups"],
-                "kubeconfig_filename": os.path.join(
-                    tempfile.gettempdir(), "QHUB_KUBECONFIG"
-                ),
-            },
-        )
-    elif config["provider"] == "gcp":
-        stage_outputs[directory] = terraform.deploy(
-            os.path.join(directory, config["provider"]),
-            input_vars={
-                "name": config["project_name"],
-                "environment": config["namespace"],
-                "region": config["google_cloud_platform"]["region"],
-                "project_id": config["google_cloud_platform"]["project"],
-                "node_groups": [
-                    {
-                        "name": key,
-                        "min_size": value["min_nodes"],
-                        "max_size": value["max_nodes"],
-                        "instance_type": value["instance"],
-                        **value,
-                    }
-                    for key, value in config["google_cloud_platform"][
-                        "node_groups"
-                    ].items()
-                ],
-                "kubeconfig_filename": os.path.join(
-                    tempfile.gettempdir(), "QHUB_KUBECONFIG"
-                ),
-            },
-        )
-    elif config["provider"] == "azure":
-        stage_outputs[directory] = terraform.deploy(
-            os.path.join(directory, config["provider"]),
-            input_vars={
-                "name": config["project_name"],
-                "environment": config["namespace"],
-                "region": config["azure"]["region"],
-                "kubernetes_version": config["azure"]["kubernetes_version"],
-                "node_groups": config["azure"]["node_groups"],
-                "kubeconfig_filename": os.path.join(
-                    tempfile.gettempdir(), "QHUB_KUBECONFIG"
-                ),
-                "resource_group_name": f'{config["project_name"]}-{config["namespace"]}',
-                "node_resource_group_name": f'{config["project_name"]}-{config["namespace"]}-node-resource-group',
-            },
-        )
-    elif config["provider"] == "aws":
-        stage_outputs[directory] = terraform.deploy(
-            os.path.join(directory, config["provider"]),
-            input_vars={
-                "name": config["project_name"],
-                "environment": config["namespace"],
-                "node_groups": [
-                    {
-                        "name": key,
-                        "min_size": value["min_nodes"],
-                        "desired_size": value["min_nodes"],
-                        "max_size": value["max_nodes"],
-                        "gpu": value.get("gpu", False),
-                        "instance_type": value["instance"],
-                    }
-                    for key, value in config["amazon_web_services"][
-                        "node_groups"
-                    ].items()
-                ],
-                "kubeconfig_filename": os.path.join(
-                    tempfile.gettempdir(), "QHUB_KUBECONFIG"
-                ),
-            },
-        )
-    else:
-        raise NotImplementedError(
-            f'provider {config["provider"]} not implemented for directory={directory}'
-        )
+    stage_outputs[directory] = terraform.deploy(
+        os.path.join(directory, config["provider"]),
+        input_vars=input_vars.stage_02_infrastructure(stage_outputs, config),
+    )
 
     if check:
-        check_02_infrastructure(stage_outputs, config)
-
-
-def check_02_infrastructure(stage_outputs, qhub_config):
-    from kubernetes import client, config
-    from kubernetes.client.rest import ApiException
-
-    directory = "stages/02-infrastructure"
-    config.load_kube_config(
-        config_file=stage_outputs["stages/02-infrastructure"]["kubeconfig_filename"][
-            "value"
-        ]
-    )
-
-    try:
-        api_instance = client.CoreV1Api()
-        result = api_instance.list_node()
-    except ApiException:
-        print(
-            f"ERROR: After stage directory={directory} unable to connect to kubernetes cluster"
-        )
-        sys.exit(1)
-
-    if len(result.items) < 1:
-        print(
-            f"ERROR: After stage directory={directory} no nodes provisioned within kubernetes cluster"
-        )
-        sys.exit(1)
-
-    print(
-        f"After stage directory={directory} kubernetes cluster successfully provisioned"
-    )
+        checks.stage_02_infrastructure(stage_outputs, config)
 
 
 def provision_03_kubernetes_initialize(stage_outputs, config, check=True):
@@ -370,49 +98,11 @@ def provision_03_kubernetes_initialize(stage_outputs, config, check=True):
 
     stage_outputs[directory] = terraform.deploy(
         directory=directory,
-        input_vars={
-            "name": config["project_name"],
-            "environment": config["namespace"],
-            "cloud-provider": config["provider"],
-            "aws-region": config.get("amazon_web_services", {}).get("region"),
-            "external_container_reg": config.get(
-                "external_container_reg", {"enabled": False}
-            ),
-        },
+        input_vars=input_vars.stage_03_kubernetes_initialize(stage_outputs, config),
     )
 
     if check:
-        check_03_kubernetes_initialize(stage_outputs, config)
-
-
-def check_03_kubernetes_initialize(stage_outputs, qhub_config):
-    from kubernetes import client, config
-    from kubernetes.client.rest import ApiException
-
-    directory = "stages/03-kubernetes-initialize"
-    config.load_kube_config(
-        config_file=stage_outputs["stages/02-infrastructure"]["kubeconfig_filename"][
-            "value"
-        ]
-    )
-
-    try:
-        api_instance = client.CoreV1Api()
-        result = api_instance.list_namespace()
-    except ApiException:
-        print(
-            f"ERROR: After stage directory={directory} unable to connect to kubernetes cluster"
-        )
-        sys.exit(1)
-
-    namespaces = {_.metadata.name for _ in result.items}
-    if qhub_config["namespace"] not in namespaces:
-        print(
-            f"ERROR: After stage directory={directory} namespace={config['namespace']} not provisioned within kubernetes cluster"
-        )
-        sys.exit(1)
-
-    print(f"After stage directory={directory} kubernetes initialized successfully")
+        checks.stage_03_kubernetes_initialize(stage_outputs, config)
 
 
 def provision_04_kubernetes_ingress(stage_outputs, config, check=True):
@@ -420,69 +110,22 @@ def provision_04_kubernetes_ingress(stage_outputs, config, check=True):
 
     stage_outputs[directory] = terraform.deploy(
         directory=directory,
-        input_vars={
-            "name": config["project_name"],
-            "environment": config["namespace"],
-            "node_groups": calculate_note_groups(config),
-            "enable-certificates": (config["certificate"]["type"] == "lets-encrypt"),
-            "acme-email": config["certificate"].get("acme_email"),
-            "acme-server": config["certificate"].get("acme_server"),
-            "certificate-secret-name": config["certificate"]["secret_name"]
-            if config["certificate"]["type"] == "existing"
-            else None,
-        },
+        input_vars=input_vars.stage_04_kubernetes_ingress(stage_outputs, config),
     )
 
     if check:
-        check_04_kubernetes_ingress(stage_outputs, config)
+        checks.stage_04_kubernetes_ingress(stage_outputs, config)
 
 
-def check_04_kubernetes_ingress(stage_outputs, qhub_config):
-    directory = "stages/04-kubernetes-ingress"
+def add_clearml_dns(zone_name, record_name, record_type, ip_or_hostname):
+    dns_records = [
+        f"app.clearml.{record_name}",
+        f"api.clearml.{record_name}",
+        f"files.clearml.{record_name}",
+    ]
 
-    def _attempt_tcp_connect(host, port, num_attempts=NUM_ATTEMPTS, timeout=TIMEOUT):
-        for i in range(num_attempts):
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            try:
-                # normalize hostname to ip address
-                ip = socket.gethostbyname(host)
-                s.settimeout(5)
-                result = s.connect_ex((ip, port))
-                if result == 0:
-                    print(f"Attempt {i+1} succedded to connect to tcp://{ip}:{port}")
-                    return True
-                print(f"Attempt {i+1} failed to connect to tcp tcp://{ip}:{port}")
-            except socket.gaierror:
-                print(f"Attempt {i+1} failed to get IP for {host}...")
-            finally:
-                s.close()
-
-            time.sleep(timeout)
-
-        return False
-
-    tcp_ports = {
-        80,  # http
-        443,  # https
-        8022,  # jupyterhub-ssh ssh
-        8023,  # jupyterhub-ssh sftp
-        9080,  # minio
-        8786,  # dask-scheduler
-    }
-    ip_or_name = stage_outputs[directory]["load_balancer_address"]["value"]
-    host = ip_or_name["hostname"] or ip_or_name["ip"]
-    host = host.strip("\n")
-
-    for port in tcp_ports:
-        if not _attempt_tcp_connect(host, port):
-            print(
-                f"ERROR: After stage directory={directory} unable to connect to ingress host={host} port={port}"
-            )
-            sys.exit(1)
-
-    print(
-        f"After stage directory={directory} kubernetes ingress available on tcp ports={tcp_ports}"
-    )
+    for dns_record in dns_records:
+        update_record(zone_name, dns_record, record_type, ip_or_hostname)
 
 
 def provision_ingress_dns(
@@ -525,57 +168,7 @@ def provision_ingress_dns(
         )
 
     if check:
-        check_ingress_dns(stage_outputs, config, disable_prompt)
-
-
-def check_ingress_dns(stage_outputs, config, disable_prompt):
-    directory = "stages/04-kubernetes-ingress"
-
-    ip_or_name = stage_outputs[directory]["load_balancer_address"]["value"]
-    ip = socket.gethostbyname(ip_or_name["hostname"] or ip_or_name["ip"])
-    domain_name = config["domain"]
-
-    def _attempt_dns_lookup(
-        domain_name, ip, num_attempts=NUM_ATTEMPTS, timeout=TIMEOUT
-    ):
-        for i in range(num_attempts):
-            try:
-                resolved_ip = socket.gethostbyname(domain_name)
-                if resolved_ip == ip:
-                    print(
-                        f"DNS configured domain={domain_name} matches ingress ip={ip}"
-                    )
-                    return True
-                else:
-                    print(
-                        f"Attempt {i+1} polling DNS domain={domain_name} does not match ip={ip} instead got {resolved_ip}"
-                    )
-            except socket.gaierror:
-                print(
-                    f"Attempt {i+1} polling DNS domain={domain_name} record does not exist"
-                )
-            time.sleep(timeout)
-        return False
-
-    attempt = 0
-    while not _attempt_dns_lookup(domain_name, ip):
-        sleeptime = 60 * (2 ** attempt)
-        if not disable_prompt:
-            input(
-                f"After attempting to poll the DNS, the record for domain={domain_name} appears not to exist, "
-                f"has recently been updated, or has yet to fully propogate. This non-deterministic behavior is likely due to "
-                f"DNS caching and will likely resolve itself in a few minutes.\n\n\tTo poll the DNS again in {sleeptime} seconds "
-                f"[Press Enter].\n\n...otherwise kill the process and run the deployment again later..."
-            )
-
-        print(f"Will attempt to poll DNS again in {sleeptime} seconds...")
-        time.sleep(sleeptime)
-        attempt += 1
-        if attempt == 5:
-            print(
-                f"ERROR: After stage directory={directory} DNS domain={domain_name} does not point to ip={ip}"
-            )
-            sys.exit(1)
+        checks.check_ingress_dns(stage_outputs, config, disable_prompt)
 
 
 def provision_05_kubernetes_keycloak(stage_outputs, config, check=True):
@@ -583,273 +176,37 @@ def provision_05_kubernetes_keycloak(stage_outputs, config, check=True):
 
     stage_outputs[directory] = terraform.deploy(
         directory=directory,
-        input_vars={
-            "name": config["project_name"],
-            "environment": config["namespace"],
-            "endpoint": config["domain"],
-            "initial-root-password": config["security"]["keycloak"][
-                "initial_root_password"
-            ],
-            "overrides": [
-                json.dumps(config["security"]["keycloak"].get("overrides", {}))
-            ],
-            "node-group": calculate_note_groups(config)["general"],
-        },
+        input_vars=input_vars.stage_05_kubernetes_keycloak(stage_outputs, config),
     )
 
     if check:
-        check_05_kubernetes_keycloak(stage_outputs, config)
-
-
-def check_05_kubernetes_keycloak(stage_outputs, config):
-    directory = "stages/05-kubernetes-keycloak"
-
-    from keycloak import KeycloakAdmin
-    from keycloak.exceptions import KeycloakError
-
-    keycloak_url = (
-        f"{stage_outputs[directory]['keycloak_credentials']['value']['url']}/auth/"
-    )
-
-    def _attempt_keycloak_connection(
-        keycloak_url,
-        username,
-        password,
-        realm_name,
-        client_id,
-        verify=False,
-        num_attempts=NUM_ATTEMPTS,
-        timeout=TIMEOUT,
-    ):
-        for i in range(num_attempts):
-            try:
-                KeycloakAdmin(
-                    keycloak_url,
-                    username=username,
-                    password=password,
-                    realm_name=realm_name,
-                    client_id=client_id,
-                    verify=verify,
-                )
-                print(f"Attempt {i+1} succeded connecting to keycloak master realm")
-                return True
-            except KeycloakError:
-                print(f"Attempt {i+1} failed connecting to keycloak master realm")
-            time.sleep(timeout)
-        return False
-
-    if not _attempt_keycloak_connection(
-        keycloak_url,
-        stage_outputs[directory]["keycloak_credentials"]["value"]["username"],
-        stage_outputs[directory]["keycloak_credentials"]["value"]["password"],
-        stage_outputs[directory]["keycloak_credentials"]["value"]["realm"],
-        stage_outputs[directory]["keycloak_credentials"]["value"]["client_id"],
-        verify=False,
-    ):
-        print(
-            f"ERROR: unable to connect to keycloak master realm at url={keycloak_url} with root credentials"
-        )
-        sys.exit(1)
-
-    print("Keycloak service successfully started")
+        checks.stage_05_kubernetes_keycloak(stage_outputs, config)
 
 
 def provision_06_kubernetes_keycloak_configuration(stage_outputs, config, check=True):
     directory = "stages/06-kubernetes-keycloak-configuration"
-    realm_id = "qhub"
 
     stage_outputs[directory] = terraform.deploy(
         directory=directory,
-        input_vars={
-            "realm": realm_id,
-            "realm_display_name": config["security"]["keycloak"].get(
-                "realm_display_name", realm_id
-            ),
-            "authentication": config["security"]["authentication"],
-            "default_project_groups": ["users"]
-            if config["security"].get("shared_users_group", False)
-            else [],
-        },
+        input_vars=input_vars.stage_06_kubernetes_keycloak_configuration(
+            stage_outputs, config
+        ),
     )
 
     if check:
-        check_06_kubernetes_keycloak_configuration(stage_outputs, config)
-
-
-def check_06_kubernetes_keycloak_configuration(stage_outputs, config):
-    directory = "stages/05-kubernetes-keycloak"
-
-    from keycloak import KeycloakAdmin
-    from keycloak.exceptions import KeycloakError
-
-    keycloak_url = (
-        f"{stage_outputs[directory]['keycloak_credentials']['value']['url']}/auth/"
-    )
-
-    def _attempt_keycloak_connection(
-        keycloak_url,
-        username,
-        password,
-        realm_name,
-        client_id,
-        qhub_realm,
-        verify=False,
-        num_attempts=NUM_ATTEMPTS,
-        timeout=TIMEOUT,
-    ):
-        for i in range(num_attempts):
-            try:
-                realm_admin = KeycloakAdmin(
-                    keycloak_url,
-                    username=username,
-                    password=password,
-                    realm_name=realm_name,
-                    client_id=client_id,
-                    verify=verify,
-                )
-                existing_realms = {_["id"] for _ in realm_admin.get_realms()}
-                if qhub_realm in existing_realms:
-                    print(
-                        f"Attempt {i+1} succeded connecting to keycloak and qhub realm={qhub_realm} exists"
-                    )
-                    return True
-                else:
-                    print(
-                        f"Attempt {i+1} succeeded connecting to keycloak but qhub realm did not exist"
-                    )
-            except KeycloakError:
-                print(f"Attempt {i+1} failed connecting to keycloak master realm")
-            time.sleep(timeout)
-        return False
-
-    if not _attempt_keycloak_connection(
-        keycloak_url,
-        stage_outputs[directory]["keycloak_credentials"]["value"]["username"],
-        stage_outputs[directory]["keycloak_credentials"]["value"]["password"],
-        stage_outputs[directory]["keycloak_credentials"]["value"]["realm"],
-        stage_outputs[directory]["keycloak_credentials"]["value"]["client_id"],
-        qhub_realm=stage_outputs["stages/06-kubernetes-keycloak-configuration"][
-            "realm_id"
-        ]["value"],
-        verify=False,
-    ):
-        print(
-            "ERROR: unable to connect to keycloak master realm and ensure that qhub realm exists"
-        )
-        sys.exit(1)
-
-    print("Keycloak service successfully started with qhub realm")
+        checks.stage_06_kubernetes_keycloak_configuration(stage_outputs, config)
 
 
 def provision_07_kubernetes_services(stage_outputs, config, check=True):
     directory = "stages/07-kubernetes-services"
 
-    final_logout_uri = f"https://{config['domain']}/hub/login"
-
-    # Compound any logout URLs from extensions so they are are logged out in succession
-    # when Keycloak and JupyterHub are logged out
-    for ext in config.get("tf_extensions", []):
-        if ext.get("logout", "") != "":
-            final_logout_uri = "{}?{}".format(
-                f"https://{config['domain']}/{ext['urlslug']}{ext['logout']}",
-                urlencode({"redirect_uri": final_logout_uri}),
-            )
-
     stage_outputs[directory] = terraform.deploy(
         directory=directory,
-        input_vars={
-            "name": config["project_name"],
-            "environment": config["namespace"],
-            "endpoint": config["domain"],
-            "realm_id": stage_outputs["stages/06-kubernetes-keycloak-configuration"][
-                "realm_id"
-            ]["value"],
-            "node_groups": calculate_note_groups(config),
-            # conda-store
-            "conda-store-environments": config["environments"],
-            "conda-store-storage": config["storage"]["conda_store"],
-            "conda-store-image": split_docker_image_name(
-                config["default_images"]["conda_store"]
-            ),
-            # jupyterhub
-            "cdsdashboards": config["cdsdashboards"],
-            "jupyterhub-theme": config["theme"]["jupyterhub"],
-            "jupyterhub-image": split_docker_image_name(
-                config["default_images"]["jupyterhub"]
-            ),
-            "jupyterhub-shared-storage": config["storage"]["shared_filesystem"],
-            "jupyterhub-shared-endpoint": stage_outputs["stages/02-infrastructure"]
-            .get("nfs_endpoint", {})
-            .get("value"),
-            "jupyterlab-profiles": config["profiles"]["jupyterlab"],
-            "jupyterlab-image": split_docker_image_name(
-                config["default_images"]["jupyterlab"]
-            ),
-            "jupyterhub-overrides": [
-                json.dumps(config.get("jupyterhub", {}).get("overrides", {}))
-            ],
-            "jupyterhub-hub-extraEnv": json.dumps(
-                config.get("jupyterhub", {})
-                .get("overrides", {})
-                .get("hub", {})
-                .get("extraEnv", [])
-            ),
-            # dask-gateway
-            "dask-gateway-image": split_docker_image_name(
-                config["default_images"]["dask_gateway"]
-            ),
-            "dask-worker-image": split_docker_image_name(
-                config["default_images"]["dask_worker"]
-            ),
-            "dask-gateway-profiles": config["profiles"]["dask_worker"],
-            # monitoring
-            "monitoring-enabled": config["monitoring"]["enabled"],
-            # prefect
-            "prefect-enabled": config.get("prefect", {}).get("enabled", False),
-            "prefect-token": config.get("prefect", {}).get("token", ""),
-            "prefect-image": config.get("prefect", {}).get("image", ""),
-            "prefect-overrides": config.get("prefect", {}).get("overrides", {}),
-            # clearml
-            "clearml-enabled": config.get("clearml", {}).get("enabled", False),
-            "clearml-enable-forwardauth": config.get("clearml", {}).get(
-                "enable_forward_auth", False
-            ),
-            "jupyterhub-logout-redirect-url": final_logout_uri,
-        },
+        input_vars=input_vars.stage_07_kubernetes_services(stage_outputs, config),
     )
 
     if check:
-        check_07_kubernetes_services(stage_outputs, config)
-
-
-def check_07_kubernetes_services(stage_outputs, config):
-    directory = "stages/07-kubernetes-services"
-    import requests
-
-    # supress insecure warnings
-    import urllib3
-
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-
-    def _attempt_connect_url(
-        url, verify=False, num_attempts=NUM_ATTEMPTS, timeout=TIMEOUT
-    ):
-        for i in range(num_attempts):
-            response = requests.get(service_url, verify=verify)
-            if response.status_code < 400:
-                print(f"Attempt {i+1} health check succeded for url={url}")
-                return True
-            else:
-                print(f"Attempt {i+1} health check failed for url={url}")
-            time.sleep(timeout)
-        return False
-
-    services = stage_outputs[directory]["service_urls"]["value"]
-    for service_name, service in services.items():
-        service_url = service["health_url"]
-        if not _attempt_connect_url(service_url):
-            print(f"ERROR: Service {service_name} DOWN when checking url={service_url}")
-            sys.exit(1)
+        checks.stage_07_kubernetes_services(stage_outputs, config)
 
 
 def provision_08_qhub_tf_extensions(stage_outputs, config, check=True):
@@ -857,19 +214,7 @@ def provision_08_qhub_tf_extensions(stage_outputs, config, check=True):
 
     stage_outputs[directory] = terraform.deploy(
         directory=directory,
-        input_vars={
-            "environment": config["namespace"],
-            "endpoint": config["domain"],
-            "realm_id": stage_outputs["stages/06-kubernetes-keycloak-configuration"][
-                "realm_id"
-            ]["value"],
-            "tf_extensions": config.get("tf_extensions", []),
-            "qhub_config_yaml": config,
-            "keycloak_qhub_bot_password": stage_outputs[
-                "stages/05-kubernetes-keycloak"
-            ]["keycloak_qhub_bot_password"]["value"],
-            "helm_extensions": config.get("helm_extensions", []),
-        },
+        input_vars=input_vars.stage_08_qhub_tf_extensions(stage_outputs, config),
     )
 
     if check:
@@ -937,13 +282,42 @@ def guided_install(
     )
 
 
-def add_clearml_dns(zone_name, record_name, record_type, ip_or_hostname):
-    logger.info(f"Setting DNS record for ClearML for record: {record_name}")
-    dns_records = [
-        f"app.clearml.{record_name}",
-        f"api.clearml.{record_name}",
-        f"files.clearml.{record_name}",
-    ]
+def deploy_configuration(
+    config,
+    dns_provider,
+    dns_auto_provision,
+    disable_prompt,
+    skip_remote_state_provision,
+):
+    if config.get("prevent_deploy", False):
+        # Note if we used the Pydantic model properly, we might get that qhub_config.prevent_deploy always exists but defaults to False
+        raise ValueError(
+            textwrap.dedent(
+                """
+        Deployment prevented due to the prevent_deploy setting in your qhub-config.yaml file.
+        You could remove that field to deploy your QHub, but please do NOT do so without fully understanding why that value was set in the first place.
 
-    for dns_record in dns_records:
-        update_record(zone_name, dns_record, record_type, ip_or_hostname)
+        It may have been set during an upgrade of your qhub-config.yaml file because we do not believe it is safe to redeploy the new
+        version of QHub without having a full backup of your system ready to restore. It may be known that an in-situ upgrade is impossible
+        and that redeployment will tear down your existing infrastructure before creating an entirely new QHub without your old data.
+
+        PLEASE get in touch with Quansight at https://github.com/Quansight/qhub for assistance in proceeding.
+        Your data may be at risk without our guidance.
+        """
+            )
+        )
+
+    logger.info(f'All qhub endpoints will be under https://{config["domain"]}')
+
+    with timer(logger, "deploying QHub"):
+        try:
+            guided_install(
+                config,
+                dns_provider,
+                dns_auto_provision,
+                disable_prompt,
+                skip_remote_state_provision,
+            )
+        except subprocess.CalledProcessError as e:
+            logger.error(e.output)
+            raise e

--- a/qhub/destroy.py
+++ b/qhub/destroy.py
@@ -1,8 +1,8 @@
 import logging
 import os
-import tempfile
 
 from qhub.utils import timer, check_cloud_credentials
+from qhub.stages import input_vars, state_imports
 from qhub.provider import terraform
 
 logger = logging.getLogger(__name__)
@@ -11,207 +11,27 @@ logger = logging.getLogger(__name__)
 def destroy_01_terraform_state(config):
     directory = "stages/01-terraform-state"
 
-    if config["provider"] == "do":
-        terraform.deploy(
-            terraform_import=True,
-            # acl and force_destroy do not import properly
-            # and only get refreshed properly with an apply
-            terraform_apply=True,
-            terraform_destroy=True,
-            directory=os.path.join(directory, config["provider"]),
-            input_vars={
-                "name": config["project_name"],
-                "namespace": config["namespace"],
-                "region": config["digital_ocean"]["region"],
-            },
-            state_imports=[
-                (
-                    "module.terraform-state.module.spaces.digitalocean_spaces_bucket.main",
-                    f"{config['digital_ocean']['region']},{config['project_name']}-{config['namespace']}-terraform-state",
-                )
-            ],
-        )
-    elif config["provider"] == "gcp":
-        terraform.deploy(
-            terraform_import=True,
-            # acl and force_destroy do not import properly
-            # and only get refreshed properly with an apply
-            terraform_apply=True,
-            terraform_destroy=True,
-            directory=os.path.join(directory, config["provider"]),
-            input_vars={
-                "name": config["project_name"],
-                "namespace": config["namespace"],
-                "region": config["google_cloud_platform"]["region"],
-            },
-            state_imports=[
-                (
-                    "module.terraform-state.module.gcs.google_storage_bucket.static-site",
-                    f"{config['project_name']}-{config['namespace']}-terraform-state",
-                )
-            ],
-        )
-    elif config["provider"] == "azure":
-        subscription_id = os.environ["ARM_SUBSCRIPTION_ID"]
-        resource_group_name = f"{config['project_name']}-{config['namespace']}"
-        resource_group_name_safe = resource_group_name.replace("-", "")
-        resource_group_url = f"/subscriptions/{subscription_id}/resourceGroups/{config['project_name']}-{config['namespace']}"
-
-        terraform.deploy(
-            terraform_import=True,
-            terraform_apply=False,
-            terraform_destroy=True,
-            directory=os.path.join(directory, config["provider"]),
-            input_vars={
-                "name": config["project_name"],
-                "namespace": config["namespace"],
-                "region": config["azure"]["region"],
-                "storage_account_postfix": config["azure"]["storage_account_postfix"],
-            },
-            state_imports=[
-                (
-                    "module.terraform-state.azurerm_resource_group.terraform-resource-group",
-                    resource_group_url,
-                ),
-                (
-                    "module.terraform-state.azurerm_storage_account.terraform-storage-account",
-                    f"{resource_group_url}/providers/Microsoft.Storage/storageAccounts/{resource_group_name_safe}{config['azure']['storage_account_postfix']}",
-                ),
-                (
-                    "module.terraform-state.azurerm_storage_container.storage_container",
-                    f"https://{resource_group_name_safe}{config['azure']['storage_account_postfix']}.blob.core.windows.net/{resource_group_name}state",
-                ),
-            ],
-        )
-    elif config["provider"] == "aws":
-        terraform.deploy(
-            terraform_import=True,
-            # acl and force_destroy do not import properly
-            # and only get refreshed properly with an apply
-            terraform_apply=True,
-            terraform_destroy=True,
-            directory=os.path.join(directory, config["provider"]),
-            input_vars={
-                "name": config["project_name"],
-                "namespace": config["namespace"],
-            },
-            state_imports=[
-                (
-                    "module.terraform-state.aws_s3_bucket.terraform-state",
-                    f"{config['project_name']}-{config['namespace']}-terraform-state",
-                ),
-                (
-                    "module.terraform-state.aws_dynamodb_table.terraform-state-lock",
-                    f"{config['project_name']}-{config['namespace']}-terraform-state-lock",
-                ),
-            ],
-        )
-    else:
-        raise NotImplementedError(
-            f'provider {config["provider"]} not implemented for directory={directory}'
-        )
+    terraform.deploy(
+        terraform_import=True,
+        # acl and force_destroy do not import properly
+        # and only get refreshed properly with an apply
+        terraform_apply=True,
+        terraform_destroy=True,
+        directory=os.path.join(directory, config["provider"]),
+        input_vars=input_vars.stage_01_terraform_state({}, config),
+        state_imports=state_imports.stage_01_terraform_state({}, config),
+    )
 
 
 def destroy_02_infrastructure(config):
     directory = "stages/02-infrastructure"
 
-    if config["provider"] == "local":
-        terraform.deploy(
-            terraform_apply=False,
-            terraform_destroy=True,
-            directory=os.path.join(directory, config["provider"]),
-            input_vars={"kube_context": config["local"].get("kube_context")},
-        )
-    elif config["provider"] == "do":
-        terraform.deploy(
-            terraform_apply=False,
-            terraform_destroy=True,
-            directory=os.path.join(directory, config["provider"]),
-            input_vars={
-                "name": config["project_name"],
-                "environment": config["namespace"],
-                "region": config["digital_ocean"]["region"],
-                "kubernetes_version": config["digital_ocean"]["kubernetes_version"],
-                "node_groups": config["digital_ocean"]["node_groups"],
-                "kubeconfig_filename": os.path.join(
-                    tempfile.gettempdir(), "QHUB_KUBECONFIG"
-                ),
-            },
-        )
-    elif config["provider"] == "gcp":
-        terraform.deploy(
-            terraform_apply=False,
-            terraform_destroy=True,
-            directory=os.path.join(directory, config["provider"]),
-            input_vars={
-                "name": config["project_name"],
-                "environment": config["namespace"],
-                "region": config["google_cloud_platform"]["region"],
-                "project_id": config["google_cloud_platform"]["project"],
-                "node_groups": [
-                    {
-                        "name": key,
-                        "min_size": value["min_nodes"],
-                        "max_size": value["max_nodes"],
-                        **value,
-                    }
-                    for key, value in config["google_cloud_platform"][
-                        "node_groups"
-                    ].items()
-                ],
-                "kubeconfig_filename": os.path.join(
-                    tempfile.gettempdir(), "QHUB_KUBECONFIG"
-                ),
-            },
-        )
-    elif config["provider"] == "azure":
-        terraform.deploy(
-            terraform_apply=False,
-            terraform_destroy=True,
-            directory=os.path.join(directory, config["provider"]),
-            input_vars={
-                "name": config["project_name"],
-                "environment": config["namespace"],
-                "region": config["azure"]["region"],
-                "kubernetes_version": config["azure"]["kubernetes_version"],
-                "node_groups": config["azure"]["node_groups"],
-                "kubeconfig_filename": os.path.join(
-                    tempfile.gettempdir(), "QHUB_KUBECONFIG"
-                ),
-                "resource_group_name": f'{config["project_name"]}-{config["namespace"]}',
-                "node_resource_group_name": f'{config["project_name"]}-{config["namespace"]}-node-resource-group',
-            },
-        )
-    elif config["provider"] == "aws":
-        terraform.deploy(
-            terraform_apply=False,
-            terraform_destroy=True,
-            directory=os.path.join(directory, config["provider"]),
-            input_vars={
-                "name": config["project_name"],
-                "environment": config["namespace"],
-                "node_groups": [
-                    {
-                        "name": key,
-                        "min_size": value["min_nodes"],
-                        "desired_size": value["min_nodes"],
-                        "max_size": value["max_nodes"],
-                        "gpu": value.get("gpu", False),
-                        "instance_type": value["instance"],
-                    }
-                    for key, value in config["amazon_web_services"][
-                        "node_groups"
-                    ].items()
-                ],
-                "kubeconfig_filename": os.path.join(
-                    tempfile.gettempdir(), "QHUB_KUBECONFIG"
-                ),
-            },
-        )
-    else:
-        raise NotImplementedError(
-            f'provider {config["provider"]} not implemented for directory={directory}'
-        )
+    terraform.deploy(
+        terraform_apply=False,
+        terraform_destroy=True,
+        directory=os.path.join(directory, config["provider"]),
+        input_vars=input_vars.stage_02_infrastructure({}, config),
+    )
 
 
 def destroy_configuration(config):

--- a/qhub/stages/checks.py
+++ b/qhub/stages/checks.py
@@ -1,0 +1,315 @@
+import sys
+import time
+import socket
+
+
+# check and retry settings
+NUM_ATTEMPTS = 10
+TIMEOUT = 10  # seconds
+
+
+def stage_02_infrastructure(stage_outputs, qhub_config):
+    from kubernetes import client, config
+    from kubernetes.client.rest import ApiException
+
+    directory = "stages/02-infrastructure"
+    config.load_kube_config(
+        config_file=stage_outputs["stages/02-infrastructure"]["kubeconfig_filename"][
+            "value"
+        ]
+    )
+
+    try:
+        api_instance = client.CoreV1Api()
+        result = api_instance.list_node()
+    except ApiException:
+        print(
+            f"ERROR: After stage directory={directory} unable to connect to kubernetes cluster"
+        )
+        sys.exit(1)
+
+    if len(result.items) < 1:
+        print(
+            f"ERROR: After stage directory={directory} no nodes provisioned within kubernetes cluster"
+        )
+        sys.exit(1)
+
+    print(
+        f"After stage directory={directory} kubernetes cluster successfully provisioned"
+    )
+
+
+def stage_03_kubernetes_initialize(stage_outputs, qhub_config):
+    from kubernetes import client, config
+    from kubernetes.client.rest import ApiException
+
+    directory = "stages/03-kubernetes-initialize"
+    config.load_kube_config(
+        config_file=stage_outputs["stages/02-infrastructure"]["kubeconfig_filename"][
+            "value"
+        ]
+    )
+
+    try:
+        api_instance = client.CoreV1Api()
+        result = api_instance.list_namespace()
+    except ApiException:
+        print(
+            f"ERROR: After stage directory={directory} unable to connect to kubernetes cluster"
+        )
+        sys.exit(1)
+
+    namespaces = {_.metadata.name for _ in result.items}
+    if qhub_config["namespace"] not in namespaces:
+        print(
+            f"ERROR: After stage directory={directory} namespace={config['namespace']} not provisioned within kubernetes cluster"
+        )
+        sys.exit(1)
+
+    print(f"After stage directory={directory} kubernetes initialized successfully")
+
+
+def stage_04_kubernetes_ingress(stage_outputs, qhub_config):
+    directory = "stages/04-kubernetes-ingress"
+
+    def _attempt_tcp_connect(host, port, num_attempts=NUM_ATTEMPTS, timeout=TIMEOUT):
+        for i in range(num_attempts):
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                # normalize hostname to ip address
+                ip = socket.gethostbyname(host)
+                s.settimeout(5)
+                result = s.connect_ex((ip, port))
+                if result == 0:
+                    print(f"Attempt {i+1} succedded to connect to tcp://{ip}:{port}")
+                    return True
+                print(f"Attempt {i+1} failed to connect to tcp tcp://{ip}:{port}")
+            except socket.gaierror:
+                print(f"Attempt {i+1} failed to get IP for {host}...")
+            finally:
+                s.close()
+
+            time.sleep(timeout)
+
+        return False
+
+    tcp_ports = {
+        80,  # http
+        443,  # https
+        8022,  # jupyterhub-ssh ssh
+        8023,  # jupyterhub-ssh sftp
+        9080,  # minio
+        8786,  # dask-scheduler
+    }
+    ip_or_name = stage_outputs[directory]["load_balancer_address"]["value"]
+    host = ip_or_name["hostname"] or ip_or_name["ip"]
+    host = host.strip("\n")
+
+    for port in tcp_ports:
+        if not _attempt_tcp_connect(host, port):
+            print(
+                f"ERROR: After stage directory={directory} unable to connect to ingress host={host} port={port}"
+            )
+            sys.exit(1)
+
+    print(
+        f"After stage directory={directory} kubernetes ingress available on tcp ports={tcp_ports}"
+    )
+
+
+def check_ingress_dns(stage_outputs, config, disable_prompt):
+    directory = "stages/04-kubernetes-ingress"
+
+    ip_or_name = stage_outputs[directory]["load_balancer_address"]["value"]
+    ip = socket.gethostbyname(ip_or_name["hostname"] or ip_or_name["ip"])
+    domain_name = config["domain"]
+
+    def _attempt_dns_lookup(
+        domain_name, ip, num_attempts=NUM_ATTEMPTS, timeout=TIMEOUT
+    ):
+        for i in range(num_attempts):
+            try:
+                resolved_ip = socket.gethostbyname(domain_name)
+                if resolved_ip == ip:
+                    print(
+                        f"DNS configured domain={domain_name} matches ingress ip={ip}"
+                    )
+                    return True
+                else:
+                    print(
+                        f"Attempt {i+1} polling DNS domain={domain_name} does not match ip={ip} instead got {resolved_ip}"
+                    )
+            except socket.gaierror:
+                print(
+                    f"Attempt {i+1} polling DNS domain={domain_name} record does not exist"
+                )
+            time.sleep(timeout)
+        return False
+
+    attempt = 0
+    while not _attempt_dns_lookup(domain_name, ip):
+        sleeptime = 60 * (2 ** attempt)
+        if not disable_prompt:
+            input(
+                f"After attempting to poll the DNS, the record for domain={domain_name} appears not to exist, "
+                f"has recently been updated, or has yet to fully propogate. This non-deterministic behavior is likely due to "
+                f"DNS caching and will likely resolve itself in a few minutes.\n\n\tTo poll the DNS again in {sleeptime} seconds "
+                f"[Press Enter].\n\n...otherwise kill the process and run the deployment again later..."
+            )
+
+        print(f"Will attempt to poll DNS again in {sleeptime} seconds...")
+        time.sleep(sleeptime)
+        attempt += 1
+        if attempt == 5:
+            print(
+                f"ERROR: After stage directory={directory} DNS domain={domain_name} does not point to ip={ip}"
+            )
+            sys.exit(1)
+
+
+def stage_05_kubernetes_keycloak(stage_outputs, config):
+    directory = "stages/05-kubernetes-keycloak"
+
+    from keycloak import KeycloakAdmin
+    from keycloak.exceptions import KeycloakError
+
+    keycloak_url = (
+        f"{stage_outputs[directory]['keycloak_credentials']['value']['url']}/auth/"
+    )
+
+    def _attempt_keycloak_connection(
+        keycloak_url,
+        username,
+        password,
+        realm_name,
+        client_id,
+        verify=False,
+        num_attempts=NUM_ATTEMPTS,
+        timeout=TIMEOUT,
+    ):
+        for i in range(num_attempts):
+            try:
+                KeycloakAdmin(
+                    keycloak_url,
+                    username=username,
+                    password=password,
+                    realm_name=realm_name,
+                    client_id=client_id,
+                    verify=verify,
+                )
+                print(f"Attempt {i+1} succeded connecting to keycloak master realm")
+                return True
+            except KeycloakError:
+                print(f"Attempt {i+1} failed connecting to keycloak master realm")
+            time.sleep(timeout)
+        return False
+
+    if not _attempt_keycloak_connection(
+        keycloak_url,
+        stage_outputs[directory]["keycloak_credentials"]["value"]["username"],
+        stage_outputs[directory]["keycloak_credentials"]["value"]["password"],
+        stage_outputs[directory]["keycloak_credentials"]["value"]["realm"],
+        stage_outputs[directory]["keycloak_credentials"]["value"]["client_id"],
+        verify=False,
+    ):
+        print(
+            f"ERROR: unable to connect to keycloak master realm at url={keycloak_url} with root credentials"
+        )
+        sys.exit(1)
+
+    print("Keycloak service successfully started")
+
+
+def stage_06_kubernetes_keycloak_configuration(stage_outputs, config):
+    directory = "stages/05-kubernetes-keycloak"
+
+    from keycloak import KeycloakAdmin
+    from keycloak.exceptions import KeycloakError
+
+    keycloak_url = (
+        f"{stage_outputs[directory]['keycloak_credentials']['value']['url']}/auth/"
+    )
+
+    def _attempt_keycloak_connection(
+        keycloak_url,
+        username,
+        password,
+        realm_name,
+        client_id,
+        qhub_realm,
+        verify=False,
+        num_attempts=NUM_ATTEMPTS,
+        timeout=TIMEOUT,
+    ):
+        for i in range(num_attempts):
+            try:
+                realm_admin = KeycloakAdmin(
+                    keycloak_url,
+                    username=username,
+                    password=password,
+                    realm_name=realm_name,
+                    client_id=client_id,
+                    verify=verify,
+                )
+                existing_realms = {_["id"] for _ in realm_admin.get_realms()}
+                if qhub_realm in existing_realms:
+                    print(
+                        f"Attempt {i+1} succeded connecting to keycloak and qhub realm={qhub_realm} exists"
+                    )
+                    return True
+                else:
+                    print(
+                        f"Attempt {i+1} succeeded connecting to keycloak but qhub realm did not exist"
+                    )
+            except KeycloakError:
+                print(f"Attempt {i+1} failed connecting to keycloak master realm")
+            time.sleep(timeout)
+        return False
+
+    if not _attempt_keycloak_connection(
+        keycloak_url,
+        stage_outputs[directory]["keycloak_credentials"]["value"]["username"],
+        stage_outputs[directory]["keycloak_credentials"]["value"]["password"],
+        stage_outputs[directory]["keycloak_credentials"]["value"]["realm"],
+        stage_outputs[directory]["keycloak_credentials"]["value"]["client_id"],
+        qhub_realm=stage_outputs["stages/06-kubernetes-keycloak-configuration"][
+            "realm_id"
+        ]["value"],
+        verify=False,
+    ):
+        print(
+            "ERROR: unable to connect to keycloak master realm and ensure that qhub realm exists"
+        )
+        sys.exit(1)
+
+    print("Keycloak service successfully started with qhub realm")
+
+
+def stage_07_kubernetes_services(stage_outputs, config):
+    directory = "stages/07-kubernetes-services"
+    import requests
+
+    # supress insecure warnings
+    import urllib3
+
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    def _attempt_connect_url(
+        url, verify=False, num_attempts=NUM_ATTEMPTS, timeout=TIMEOUT
+    ):
+        for i in range(num_attempts):
+            response = requests.get(service_url, verify=verify)
+            if response.status_code < 400:
+                print(f"Attempt {i+1} health check succeded for url={url}")
+                return True
+            else:
+                print(f"Attempt {i+1} health check failed for url={url}")
+            time.sleep(timeout)
+        return False
+
+    services = stage_outputs[directory]["service_urls"]["value"]
+    for service_name, service in services.items():
+        service_url = service["health_url"]
+        if not _attempt_connect_url(service_url):
+            print(f"ERROR: Service {service_name} DOWN when checking url={service_url}")
+            sys.exit(1)

--- a/qhub/stages/input_vars.py
+++ b/qhub/stages/input_vars.py
@@ -255,6 +255,9 @@ def stage_07_kubernetes_services(stage_outputs, config):
         "clearml-enable-forwardauth": config.get("clearml", {}).get(
             "enable_forward_auth", False
         ),
+        "clearml-overrides": [
+            json.dumps(config.get("clearml", {}).get("overrides", {}))
+        ],
         "jupyterhub-logout-redirect-url": final_logout_uri,
     }
 

--- a/qhub/stages/input_vars.py
+++ b/qhub/stages/input_vars.py
@@ -1,0 +1,275 @@
+import os
+import tempfile
+import json
+from urllib.parse import urlencode
+
+
+def stage_01_terraform_state(stage_outputs, config):
+    if config["provider"] == "do":
+        return {
+            "name": config["project_name"],
+            "namespace": config["namespace"],
+            "region": config["digital_ocean"]["region"],
+        }
+    elif config["provider"] == "gcp":
+        return {
+            "name": config["project_name"],
+            "namespace": config["namespace"],
+            "region": config["google_cloud_platform"]["region"],
+        }
+    elif config["provider"] == "aws":
+        return {
+            "name": config["project_name"],
+            "namespace": config["namespace"],
+        }
+    elif config["provider"] == "azure":
+        return {
+            "name": config["project_name"],
+            "namespace": config["namespace"],
+            "region": config["azure"]["region"],
+            "storage_account_postfix": config["azure"]["storage_account_postfix"],
+        }
+    else:
+        return {}
+
+
+def stage_02_infrastructure(stage_outputs, config):
+    if config["provider"] == "local":
+        return {"kube_context": config["local"].get("kube_context")}
+    elif config["provider"] == "do":
+        return {
+            "name": config["project_name"],
+            "environment": config["namespace"],
+            "region": config["digital_ocean"]["region"],
+            "kubernetes_version": config["digital_ocean"]["kubernetes_version"],
+            "node_groups": config["digital_ocean"]["node_groups"],
+            "kubeconfig_filename": os.path.join(
+                tempfile.gettempdir(), "QHUB_KUBECONFIG"
+            ),
+        }
+    elif config["provider"] == "gcp":
+        return {
+            "name": config["project_name"],
+            "environment": config["namespace"],
+            "region": config["google_cloud_platform"]["region"],
+            "project_id": config["google_cloud_platform"]["project"],
+            "node_groups": [
+                {
+                    "name": key,
+                    "min_size": value["min_nodes"],
+                    "max_size": value["max_nodes"],
+                    **value,
+                }
+                for key, value in config["google_cloud_platform"]["node_groups"].items()
+            ],
+            "kubeconfig_filename": os.path.join(
+                tempfile.gettempdir(), "QHUB_KUBECONFIG"
+            ),
+        }
+    elif config["provider"] == "azure":
+        return {
+            "name": config["project_name"],
+            "environment": config["namespace"],
+            "region": config["azure"]["region"],
+            "kubernetes_version": config["azure"]["kubernetes_version"],
+            "node_groups": config["azure"]["node_groups"],
+            "kubeconfig_filename": os.path.join(
+                tempfile.gettempdir(), "QHUB_KUBECONFIG"
+            ),
+            "resource_group_name": f'{config["project_name"]}-{config["namespace"]}',
+            "node_resource_group_name": f'{config["project_name"]}-{config["namespace"]}-node-resource-group',
+        }
+    elif config["provider"] == "aws":
+        return {
+            "name": config["project_name"],
+            "environment": config["namespace"],
+            "node_groups": [
+                {
+                    "name": key,
+                    "min_size": value["min_nodes"],
+                    "desired_size": value["min_nodes"],
+                    "max_size": value["max_nodes"],
+                    "gpu": value.get("gpu", False),
+                    "instance_type": value["instance"],
+                }
+                for key, value in config["amazon_web_services"]["node_groups"].items()
+            ],
+            "kubeconfig_filename": os.path.join(
+                tempfile.gettempdir(), "QHUB_KUBECONFIG"
+            ),
+        }
+    else:
+        return {}
+
+
+def stage_03_kubernetes_initialize(stage_outputs, config):
+    return {
+        "name": config["project_name"],
+        "environment": config["namespace"],
+        "cloud-provider": config["provider"],
+        "aws-region": config.get("amazon_web_services", {}).get("region"),
+        "external_container_reg": config.get(
+            "external_container_reg", {"enabled": False}
+        ),
+    }
+
+
+def _calculate_note_groups(config):
+    if config["provider"] == "aws":
+        return {
+            group: {"key": "eks.amazonaws.com/nodegroup", "value": group}
+            for group in ["general", "user", "worker"]
+        }
+    elif config["provider"] == "gcp":
+        return {
+            group: {"key": "cloud.google.com/gke-nodepool", "value": group}
+            for group in ["general", "user", "worker"]
+        }
+    elif config["provider"] == "azure":
+        return {
+            group: {"key": "azure-node-pool", "value": group}
+            for group in ["general", "user", "worker"]
+        }
+    elif config["provider"] == "do":
+        return {
+            group: {"key": "doks.digitalocean.com/node-pool", "value": group}
+            for group in ["general", "user", "worker"]
+        }
+    else:
+        return config["local"]["node_selectors"]
+
+
+def stage_04_kubernetes_ingress(stage_outputs, config):
+    return {
+        "name": config["project_name"],
+        "environment": config["namespace"],
+        "node_groups": _calculate_note_groups(config),
+        "enable-certificates": (config["certificate"]["type"] == "lets-encrypt"),
+        "acme-email": config["certificate"].get("acme_email"),
+        "acme-server": config["certificate"].get("acme_server"),
+        "certificate-secret-name": config["certificate"]["secret_name"]
+        if config["certificate"]["type"] == "existing"
+        else None,
+    }
+
+
+def stage_05_kubernetes_keycloak(stage_outputs, config):
+    return {
+        "name": config["project_name"],
+        "environment": config["namespace"],
+        "endpoint": config["domain"],
+        "initial-root-password": config["security"]["keycloak"][
+            "initial_root_password"
+        ],
+        "overrides": [json.dumps(config["security"]["keycloak"].get("overrides", {}))],
+        "node-group": _calculate_note_groups(config)["general"],
+    }
+
+
+def stage_06_kubernetes_keycloak_configuration(stage_outputs, config):
+    realm_id = "qhub"
+
+    return {
+        "realm": realm_id,
+        "realm_display_name": config["security"]["keycloak"].get(
+            "realm_display_name", realm_id
+        ),
+        "authentication": config["security"]["authentication"],
+        "default_project_groups": ["users"]
+        if config["security"].get("shared_users_group", False)
+        else [],
+    }
+
+
+def _split_docker_image_name(image_name):
+    name, tag = image_name.split(":")
+    return {"name": name, "tag": tag}
+
+
+def stage_07_kubernetes_services(stage_outputs, config):
+    final_logout_uri = f"https://{config['domain']}/hub/login"
+
+    # Compound any logout URLs from extensions so they are are logged out in succession
+    # when Keycloak and JupyterHub are logged out
+    for ext in config.get("tf_extensions", []):
+        if ext.get("logout", "") != "":
+            final_logout_uri = "{}?{}".format(
+                f"https://{config['domain']}/{ext['urlslug']}{ext['logout']}",
+                urlencode({"redirect_uri": final_logout_uri}),
+            )
+
+    return {
+        "name": config["project_name"],
+        "environment": config["namespace"],
+        "endpoint": config["domain"],
+        "realm_id": stage_outputs["stages/06-kubernetes-keycloak-configuration"][
+            "realm_id"
+        ]["value"],
+        "node_groups": _calculate_note_groups(config),
+        # conda-store
+        "conda-store-environments": config["environments"],
+        "conda-store-storage": config["storage"]["conda_store"],
+        "conda-store-image": _split_docker_image_name(
+            config["default_images"]["conda_store"]
+        ),
+        # jupyterhub
+        "cdsdashboards": config["cdsdashboards"],
+        "jupyterhub-theme": config["theme"]["jupyterhub"],
+        "jupyterhub-image": _split_docker_image_name(
+            config["default_images"]["jupyterhub"]
+        ),
+        "jupyterhub-shared-storage": config["storage"]["shared_filesystem"],
+        "jupyterhub-shared-endpoint": stage_outputs["stages/02-infrastructure"]
+        .get("nfs_endpoint", {})
+        .get("value"),
+        "jupyterlab-profiles": config["profiles"]["jupyterlab"],
+        "jupyterlab-image": _split_docker_image_name(
+            config["default_images"]["jupyterlab"]
+        ),
+        "jupyterhub-overrides": [
+            json.dumps(config.get("jupyterhub", {}).get("overrides", {}))
+        ],
+        "jupyterhub-hub-extraEnv": json.dumps(
+            config.get("jupyterhub", {})
+            .get("overrides", {})
+            .get("hub", {})
+            .get("extraEnv", [])
+        ),
+        # dask-gateway
+        "dask-gateway-image": _split_docker_image_name(
+            config["default_images"]["dask_gateway"]
+        ),
+        "dask-worker-image": _split_docker_image_name(
+            config["default_images"]["dask_worker"]
+        ),
+        "dask-gateway-profiles": config["profiles"]["dask_worker"],
+        # monitoring
+        "monitoring-enabled": config["monitoring"]["enabled"],
+        # prefect
+        "prefect-enabled": config.get("prefect", {}).get("enabled", False),
+        "prefect-token": config.get("prefect", {}).get("token", ""),
+        "prefect-image": config.get("prefect", {}).get("image", ""),
+        "prefect-overrides": config.get("prefect", {}).get("overrides", {}),
+        # clearml
+        "clearml-enabled": config.get("clearml", {}).get("enabled", False),
+        "clearml-enable-forwardauth": config.get("clearml", {}).get(
+            "enable_forward_auth", False
+        ),
+        "jupyterhub-logout-redirect-url": final_logout_uri,
+    }
+
+
+def stage_08_qhub_tf_extensions(stage_outputs, config):
+    return {
+        "environment": config["namespace"],
+        "endpoint": config["domain"],
+        "realm_id": stage_outputs["stages/06-kubernetes-keycloak-configuration"][
+            "realm_id"
+        ]["value"],
+        "tf_extensions": config.get("tf_extensions", []),
+        "qhub_config_yaml": config,
+        "keycloak_qhub_bot_password": stage_outputs["stages/05-kubernetes-keycloak"][
+            "keycloak_qhub_bot_password"
+        ]["value"],
+        "helm_extensions": config.get("helm_extensions", []),
+    }

--- a/qhub/stages/state_imports.py
+++ b/qhub/stages/state_imports.py
@@ -1,0 +1,49 @@
+import os
+
+
+def stage_01_terraform_state(config):
+    if config["provider"] == "do":
+        return [
+            (
+                "module.terraform-state.module.spaces.digitalocean_spaces_bucket.main",
+                f"{config['digital_ocean']['region']},{config['project_name']}-{config['namespace']}-terraform-state",
+            )
+        ]
+    elif config["provider"] == "gcp":
+        return [
+            (
+                "module.terraform-state.module.gcs.google_storage_bucket.static-site",
+                f"{config['project_name']}-{config['namespace']}-terraform-state",
+            )
+        ]
+    elif config["provider"] == "azure":
+        subscription_id = os.environ["ARM_SUBSCRIPTION_ID"]
+        resource_group_name = f"{config['project_name']}-{config['namespace']}"
+        resource_group_name_safe = resource_group_name.replace("-", "")
+        resource_group_url = f"/subscriptions/{subscription_id}/resourceGroups/{config['project_name']}-{config['namespace']}"
+
+        return [
+            (
+                "module.terraform-state.azurerm_resource_group.terraform-resource-group",
+                resource_group_url,
+            ),
+            (
+                "module.terraform-state.azurerm_storage_account.terraform-storage-account",
+                f"{resource_group_url}/providers/Microsoft.Storage/storageAccounts/{resource_group_name_safe}{config['azure']['storage_account_postfix']}",
+            ),
+            (
+                "module.terraform-state.azurerm_storage_container.storage_container",
+                f"https://{resource_group_name_safe}{config['azure']['storage_account_postfix']}.blob.core.windows.net/{resource_group_name}state",
+            ),
+        ]
+    elif config["provider"] == "aws":
+        return [
+            (
+                "module.terraform-state.aws_s3_bucket.terraform-state",
+                f"{config['project_name']}-{config['namespace']}-terraform-state",
+            ),
+            (
+                "module.terraform-state.aws_dynamodb_table.terraform-state-lock",
+                f"{config['project_name']}-{config['namespace']}-terraform-state-lock",
+            ),
+        ]

--- a/qhub/utils.py
+++ b/qhub/utils.py
@@ -303,11 +303,6 @@ def modified_environ(*remove: List[str], **update: Dict[str, str]):
         [env.pop(k) for k in remove_after]
 
 
-def split_docker_image_name(image_name):
-    name, tag = image_name.split(":")
-    return {"name": name, "tag": tag}
-
-
 def deep_merge(*args):
     """Deep merge multiple dictionaries.
 


### PR DESCRIPTION
This PR is only a refactor of render, deploy, and destroy. The motivation for this is allowing for the closing of #1081. In order to properly delete the aws ingress we need to be able to get the terraform outputs from some early kubernetes stages. This PR will also allow for the easier transition to #865.

There are no modifications to the behavior of the code.

Going into more detail about the heart of the issue:

For each stage we have to supply input variables, dymanic terraform objects, terraform imports. 

We cannot run `terraform output` without supplying the proper input variables. Within deploy.py and destroy.py this was becoming repetative. Thus I've moved the definitions into a `stages/*.py` directory which will need to be done with whatever extension mechanism we chose.