### PR TITLE
Generate independet objects for terraform-state resources

### DIFF
--- a/qhub/stages/input_vars.py
+++ b/qhub/stages/input_vars.py
@@ -28,6 +28,7 @@ def stage_01_terraform_state(stage_outputs, config):
             "namespace": config["namespace"],
             "region": config["azure"]["region"],
             "storage_account_postfix": config["azure"]["storage_account_postfix"],
+            "state_resource_group_name": f'{config["project_name"]}-{config["namespace"]}-state',
         }
     else:
         return {}

--- a/qhub/stages/state_imports.py
+++ b/qhub/stages/state_imports.py
@@ -18,9 +18,10 @@ def stage_01_terraform_state(stage_outputs, config):
         ]
     elif config["provider"] == "azure":
         subscription_id = os.environ["ARM_SUBSCRIPTION_ID"]
-        resource_group_name = f"{config['project_name']}-{config['namespace']}"
-        resource_group_name_safe = resource_group_name.replace("-", "")
-        resource_group_url = f"/subscriptions/{subscription_id}/resourceGroups/{config['project_name']}-{config['namespace']}"
+        resource_name_prefix = f"{config['project_name']}-{config['namespace']}"
+        state_resource_group_name = f"{resource_name_prefix}-state"
+        state_resource_name_prefix_safe = resource_name_prefix.replace("-", "")
+        resource_group_url = f"/subscriptions/{subscription_id}/resourceGroups/{state_resource_group_name}"
 
         return [
             (
@@ -29,11 +30,11 @@ def stage_01_terraform_state(stage_outputs, config):
             ),
             (
                 "module.terraform-state.azurerm_storage_account.terraform-storage-account",
-                f"{resource_group_url}/providers/Microsoft.Storage/storageAccounts/{resource_group_name_safe}{config['azure']['storage_account_postfix']}",
+                f"{resource_group_url}/providers/Microsoft.Storage/storageAccounts/{state_resource_name_prefix_safe}{config['azure']['storage_account_postfix']}",
             ),
             (
                 "module.terraform-state.azurerm_storage_container.storage_container",
-                f"https://{resource_group_name_safe}{config['azure']['storage_account_postfix']}.blob.core.windows.net/{resource_group_name}state",
+                f"https://{state_resource_name_prefix_safe}{config['azure']['storage_account_postfix']}.blob.core.windows.net/{resource_name_prefix}-state",
             ),
         ]
     elif config["provider"] == "aws":

--- a/qhub/stages/state_imports.py
+++ b/qhub/stages/state_imports.py
@@ -25,11 +25,11 @@ def stage_01_terraform_state(stage_outputs, config):
 
         return [
             (
-                "module.terraform-state.azurerm_resource_group.terraform-resource-group",
+                "module.terraform-state.azurerm_resource_group.terraform-state-resource-group",
                 resource_group_url,
             ),
             (
-                "module.terraform-state.azurerm_storage_account.terraform-storage-account",
+                "module.terraform-state.azurerm_storage_account.terraform-state-storage-account",
                 f"{resource_group_url}/providers/Microsoft.Storage/storageAccounts/{state_resource_name_prefix_safe}{config['azure']['storage_account_postfix']}",
             ),
             (

--- a/qhub/stages/tf_objects.py
+++ b/qhub/stages/tf_objects.py
@@ -78,10 +78,10 @@ def QHubTerraformState(directory: str, qhub_config: Dict):
     elif qhub_config["provider"] == "azure":
         return TerraformBackend(
             "azurerm",
-            resource_group_name=f"{qhub_config['project_name']}-{qhub_config['namespace']}",
+            resource_group_name=f"{qhub_config['project_name']}-{qhub_config['namespace']}-state",
             # storage account must be globally unique
             storage_account_name=f"{qhub_config['project_name']}{qhub_config['namespace']}{qhub_config['azure']['storage_account_postfix']}",
-            container_name=f"{qhub_config['project_name']}-{qhub_config['namespace']}state",
+            container_name=f"{qhub_config['project_name']}-{qhub_config['namespace']}-state",
             key=f"terraform/{qhub_config['project_name']}-{qhub_config['namespace']}/{directory}",
         )
     elif qhub_config["provider"] == "local":

--- a/qhub/template/stages/01-terraform-state/azure/main.tf
+++ b/qhub/template/stages/01-terraform-state/azure/main.tf
@@ -25,9 +25,9 @@ provider "azurerm" {
 module "terraform-state" {
   source = "./modules/terraform-state"
 
-  resource_group_name     = "${var.name }-${var.namespace}"
-  location                = var.region
-  storage_account_postfix = var.storage_account_postfix
+  state_resource_group_name     = "${var.name }-${var.namespace}-terraform-state"
+  location                      = var.region
+  storage_account_postfix       = var.storage_account_postfix
 }
 
 terraform {

--- a/qhub/template/stages/01-terraform-state/azure/main.tf
+++ b/qhub/template/stages/01-terraform-state/azure/main.tf
@@ -25,7 +25,7 @@ provider "azurerm" {
 module "terraform-state" {
   source = "./modules/terraform-state"
 
-  state_resource_group_name     = "${var.name }-${var.namespace}-terraform-state"
+  name                          = "${var.name }-${var.namespace}"
   location                      = var.region
   storage_account_postfix       = var.storage_account_postfix
 }

--- a/qhub/template/stages/01-terraform-state/azure/main.tf
+++ b/qhub/template/stages/01-terraform-state/azure/main.tf
@@ -18,6 +18,11 @@ variable "storage_account_postfix" {
   type        = string
 }
 
+variable "state_resource_group_name" {
+  description = "Name for terraform state resource group"
+  type        = string
+}
+
 provider "azurerm" {
   features {}
 }
@@ -25,7 +30,8 @@ provider "azurerm" {
 module "terraform-state" {
   source = "./modules/terraform-state"
 
-  name                          = "${var.name }-${var.namespace}"
+  name                          = "${var.name}-${var.namespace}"
+  resource_group_name           = var.state_resource_group_name
   location                      = var.region
   storage_account_postfix       = var.storage_account_postfix
 }

--- a/qhub/template/stages/01-terraform-state/azure/modules/terraform-state/main.tf
+++ b/qhub/template/stages/01-terraform-state/azure/modules/terraform-state/main.tf
@@ -1,17 +1,13 @@
-locals {
-  # Prefix name for terraform state resources
-  state_resource_name = "${var.name }-${var.namespace}-terraform-state"
-}
-
-resource "azurerm_resource_group" "terraform-resource-group" {
-  name     = local.state_resource_name
+resource "azurerm_resource_group" "terraform-state-resource-group" {
+  name     = var.resource_group_name
   location = var.location
 }
 
-resource "azurerm_storage_account" "terraform-storage-account" {
-  name                     = replace("${local.state_resource_name}${var.storage_account_postfix}", "-", "") # must be unique across the entire Azure service
-  resource_group_name      = azurerm_resource_group.terraform-resource-group.name
-  location                 = azurerm_resource_group.terraform-resource-group.location
+resource "azurerm_storage_account" "terraform-state-storage-account" {
+  # name, can only consist of lowercase letters and numbers, and must be between 3 and 24 characters long
+  name                     = replace("${var.name}${var.storage_account_postfix}", "-", "") # must be unique across the entire Azure service
+  resource_group_name      = azurerm_resource_group.terraform-state-resource-group.name
+  location                 = azurerm_resource_group.terraform-state-resource-group.location
   account_tier             = "Standard"
   account_replication_type = "GRS"
 
@@ -21,7 +17,7 @@ resource "azurerm_storage_account" "terraform-storage-account" {
 }
 
 resource "azurerm_storage_container" "storage_container" {
-  name                  = local.state_resource_name
-  storage_account_name  = azurerm_storage_account.terraform-storage-account.name
+  name                  = "${var.name}-state"
+  storage_account_name  = azurerm_storage_account.terraform-state-storage-account.name
   container_access_type = "private"
 }

--- a/qhub/template/stages/01-terraform-state/azure/modules/terraform-state/main.tf
+++ b/qhub/template/stages/01-terraform-state/azure/modules/terraform-state/main.tf
@@ -1,10 +1,10 @@
 resource "azurerm_resource_group" "terraform-resource-group" {
-  name     = var.resource_group_name
+  name     = var.state_resource_group_name
   location = var.location
 }
 
 resource "azurerm_storage_account" "terraform-storage-account" {
-  name                     = replace("${var.resource_group_name}${var.storage_account_postfix}", "-", "") # must be unique across the entire Azure service
+  name                     = replace("${var.state_resource_group_name}${var.storage_account_postfix}", "-", "") # must be unique across the entire Azure service
   resource_group_name      = azurerm_resource_group.terraform-resource-group.name
   location                 = azurerm_resource_group.terraform-resource-group.location
   account_tier             = "Standard"
@@ -16,7 +16,7 @@ resource "azurerm_storage_account" "terraform-storage-account" {
 }
 
 resource "azurerm_storage_container" "storage_container" {
-  name                  = "${var.resource_group_name}state"
+  name                  = "${var.state_resource_group_name}state"
   storage_account_name  = azurerm_storage_account.terraform-storage-account.name
   container_access_type = "private"
 }

--- a/qhub/template/stages/01-terraform-state/azure/modules/terraform-state/main.tf
+++ b/qhub/template/stages/01-terraform-state/azure/modules/terraform-state/main.tf
@@ -1,10 +1,15 @@
+locals {
+  # Prefix name for terraform state resources
+  state_resource_name = "${var.name }-${var.namespace}-terraform-state"
+}
+
 resource "azurerm_resource_group" "terraform-resource-group" {
-  name     = var.state_resource_group_name
+  name     = local.state_resource_name
   location = var.location
 }
 
 resource "azurerm_storage_account" "terraform-storage-account" {
-  name                     = replace("${var.state_resource_group_name}${var.storage_account_postfix}", "-", "") # must be unique across the entire Azure service
+  name                     = replace("${local.state_resource_name}${var.storage_account_postfix}", "-", "") # must be unique across the entire Azure service
   resource_group_name      = azurerm_resource_group.terraform-resource-group.name
   location                 = azurerm_resource_group.terraform-resource-group.location
   account_tier             = "Standard"
@@ -16,7 +21,7 @@ resource "azurerm_storage_account" "terraform-storage-account" {
 }
 
 resource "azurerm_storage_container" "storage_container" {
-  name                  = "${var.state_resource_group_name}state"
+  name                  = local.state_resource_name
   storage_account_name  = azurerm_storage_account.terraform-storage-account.name
   container_access_type = "private"
 }

--- a/qhub/template/stages/01-terraform-state/azure/modules/terraform-state/variables.tf
+++ b/qhub/template/stages/01-terraform-state/azure/modules/terraform-state/variables.tf
@@ -1,5 +1,5 @@
-variable "state_resource_group_name" {
-  description = "Prefix name for terraform state resource group"
+variable "name" {
+  description = "Prefix of name to append resource"
   type        = string
 }
 

--- a/qhub/template/stages/01-terraform-state/azure/modules/terraform-state/variables.tf
+++ b/qhub/template/stages/01-terraform-state/azure/modules/terraform-state/variables.tf
@@ -1,5 +1,5 @@
-variable "resource_group_name" {
-  description = "Prefix name for terraform state"
+variable "state_resource_group_name" {
+  description = "Prefix name for terraform state resource group"
   type        = string
 }
 

--- a/qhub/template/stages/01-terraform-state/azure/modules/terraform-state/variables.tf
+++ b/qhub/template/stages/01-terraform-state/azure/modules/terraform-state/variables.tf
@@ -1,3 +1,8 @@
+variable "resource_group_name" {
+  description = "Prefix of name to append resource"
+  type        = string
+}
+
 variable "name" {
   description = "Prefix of name to append resource"
   type        = string


### PR DESCRIPTION
Fixes | Closes | Resolves #1082 

This PR should fix the above-linked issue by creating specific groups, containers, and storage resources for terraform-state files.

## Changes introduced in this PR:

- Update resource group name, for terraform state stage
- Update backend configuration following the same changes
- Add a new variable to deploy for the custom resource group name (in theory)

## Types of changes

What types of changes does your PR introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [ ] Yes
- [x] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [ ] No
