### PR TITLE
Complete implementation of destroy which goes through each stage

### DIFF
--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -3,54 +3,19 @@ import os
 import tempfile
 import textwrap
 import subprocess
-from typing import Dict
-import contextlib
 
-from qhub.utils import modified_environ, check_cloud_credentials, timer
+from qhub.utils import (
+    check_cloud_credentials,
+    timer,
+    kubernetes_provider_context,
+    keycloak_provider_context,
+)
 from qhub.stages import checks, state_imports, input_vars
 from qhub.provider import terraform
 from qhub.provider.dns.cloudflare import update_record
 
 
 logger = logging.getLogger(__name__)
-
-
-@contextlib.contextmanager
-def kubernetes_provider_context(kubernetes_credentials: Dict[str, str]):
-    credential_mapping = {
-        "config_path": "KUBE_CONFIG_PATH",
-        "config_context": "KUBE_CTX",
-        "username": "KUBE_USER",
-        "password": "KUBE_PASSWORD",
-        "client_certificate": "KUBE_CLIENT_CERT_DATA",
-        "client_key": "KUBE_CLIENT_KEY_DATA",
-        "cluster_ca_certificate": "KUBE_CLUSTER_CA_CERT_DATA",
-        "host": "KUBE_HOST",
-        "token": "KUBE_TOKEN",
-    }
-
-    credentials = {
-        credential_mapping[k]: v
-        for k, v in kubernetes_credentials.items()
-        if v is not None
-    }
-    with modified_environ(**credentials):
-        yield
-
-
-@contextlib.contextmanager
-def keycloak_provider_context(keycloak_credentials: Dict[str, str]):
-    credential_mapping = {
-        "client_id": "KEYCLOAK_CLIENT_ID",
-        "url": "KEYCLOAK_URL",
-        "username": "KEYCLOAK_USER",
-        "password": "KEYCLOAK_PASSWORD",
-        "realm": "KEYCLOAK_REALM",
-    }
-
-    credentials = {credential_mapping[k]: v for k, v in keycloak_credentials.items()}
-    with modified_environ(**credentials):
-        yield
 
 
 def provision_01_terraform_state(stage_outputs, config):

--- a/qhub/destroy.py
+++ b/qhub/destroy.py
@@ -1,7 +1,13 @@
 import logging
 import os
+import functools
 
-from qhub.utils import timer, check_cloud_credentials
+from qhub.utils import (
+    timer,
+    check_cloud_credentials,
+    kubernetes_provider_context,
+    keycloak_provider_context,
+)
 from qhub.stages import input_vars, state_imports
 from qhub.provider import terraform
 
@@ -34,19 +40,144 @@ def destroy_02_infrastructure(config):
     )
 
 
+def gather_stage_outputs(config):
+    stage_outputs = {}
+
+    _terraform_init_output = functools.partial(
+        terraform.deploy,
+        terraform_init=True,
+        terraform_import=True,
+        terraform_apply=False,
+        terraform_destroy=False,
+    )
+
+    if config["provider"] != "local" and config["terraform_state"]["type"] == "remote":
+        stage_outputs["stages/01-terraform-state"] = _terraform_init_output(
+            directory=os.path.join("stages/01-terraform-state", config["provider"]),
+            input_vars=input_vars.stage_01_terraform_state(stage_outputs, config),
+            state_imports=state_imports.stage_01_terraform_state(stage_outputs, config),
+        )
+
+    stage_outputs["stages/02-infrastructure"] = _terraform_init_output(
+        directory=os.path.join("stages/02-infrastructure", config["provider"]),
+        input_vars=input_vars.stage_02_infrastructure(stage_outputs, config),
+    )
+
+    stage_outputs["stages/03-kubernetes-initialize"] = _terraform_init_output(
+        directory="stages/03-kubernetes-initialize",
+        input_vars=input_vars.stage_03_kubernetes_initialize(stage_outputs, config),
+    )
+
+    stage_outputs["stages/04-kubernetes-ingress"] = _terraform_init_output(
+        directory="stages/04-kubernetes-ingress",
+        input_vars=input_vars.stage_04_kubernetes_ingress(stage_outputs, config),
+    )
+
+    stage_outputs["stages/05-kubernetes-keycloak"] = _terraform_init_output(
+        directory="stages/05-kubernetes-keycloak",
+        input_vars=input_vars.stage_05_kubernetes_keycloak(stage_outputs, config),
+    )
+
+    stage_outputs[
+        "stages/06-kubernetes-keycloak-configuration"
+    ] = _terraform_init_output(
+        directory="stages/06-kubernetes-keycloak-configuration",
+        input_vars=input_vars.stage_06_kubernetes_keycloak_configuration(
+            stage_outputs, config
+        ),
+    )
+
+    stage_outputs["stages/07-kubernetes-services"] = _terraform_init_output(
+        directory="stages/07-kubernetes-services",
+        input_vars=input_vars.stage_07_kubernetes_services(stage_outputs, config),
+    )
+
+    stage_outputs["stages/08-qhub-tf-extensions"] = _terraform_init_output(
+        directory="stages/08-qhub-tf-extensions",
+        input_vars=input_vars.stage_08_qhub_tf_extensions(stage_outputs, config),
+    )
+
+    return stage_outputs
+
+
+def destroy_stages(stage_outputs, config):
+    _terraform_destroy = functools.partial(
+        terraform.deploy,
+        terraform_init=True,
+        terraform_import=True,
+        terraform_apply=False,
+        terraform_destroy=True,
+    )
+
+    with kubernetes_provider_context(
+        stage_outputs["stages/02-infrastructure"]["kubernetes_credentials"]["value"]
+    ):
+        with keycloak_provider_context(
+            stage_outputs["stages/05-kubernetes-keycloak"]["keycloak_credentials"][
+                "value"
+            ]
+        ):
+            _terraform_destroy(
+                directory="stages/08-qhub-tf-extensions",
+                input_vars=input_vars.stage_08_qhub_tf_extensions(
+                    stage_outputs, config
+                ),
+            )
+
+            _terraform_destroy(
+                directory="stages/07-kubernetes-services",
+                input_vars=input_vars.stage_07_kubernetes_services(
+                    stage_outputs, config
+                ),
+            )
+
+            _terraform_destroy(
+                directory="stages/06-kubernetes-keycloak-configuration",
+                input_vars=input_vars.stage_06_kubernetes_keycloak_configuration(
+                    stage_outputs, config
+                ),
+            )
+
+        _terraform_destroy(
+            directory="stages/05-kubernetes-keycloak",
+            input_vars=input_vars.stage_05_kubernetes_keycloak(stage_outputs, config),
+        )
+
+        _terraform_destroy(
+            directory="stages/04-kubernetes-ingress",
+            input_vars=input_vars.stage_04_kubernetes_ingress(stage_outputs, config),
+        )
+
+        _terraform_destroy(
+            directory="stages/03-kubernetes-initialize",
+            input_vars=input_vars.stage_03_kubernetes_initialize(stage_outputs, config),
+        )
+
+    _terraform_destroy(
+        directory=os.path.join("stages/02-infrastructure", config["provider"]),
+        input_vars=input_vars.stage_02_infrastructure(stage_outputs, config),
+    )
+
+    if config["provider"] != "local" and config["terraform_state"]["type"] == "remote":
+        _terraform_destroy(
+            # acl and force_destroy do not import properly
+            # and only get refreshed properly with an apply
+            terraform_apply=True,
+            directory=os.path.join("stages/01-terraform-state", config["provider"]),
+            input_vars=input_vars.stage_01_terraform_state(stage_outputs, config),
+        )
+
+
 def destroy_configuration(config):
     logger.info(
         """Removing all infrastructure, your local files will still remain,
     you can use 'qhub deploy' to re-install infrastructure using same config file\n"""
     )
+    check_cloud_credentials(config)
+
+    # Populate stage_outputs to determine progress of deployment and
+    # get credentials to kubernetes and keycloak context
+    stage_outputs = gather_stage_outputs(config)
 
     with timer(logger, "destroying QHub"):
-        # 01 Check Environment Variables
-        check_cloud_credentials(config)
-
-        destroy_02_infrastructure(config)
-        if (
-            config["provider"] != "local"
-            and config["terraform_state"]["type"] == "remote"
-        ):
-            destroy_01_terraform_state(config)
+        destroy_stages(stage_outputs, config)

--- a/qhub/render.py
+++ b/qhub/render.py
@@ -116,7 +116,7 @@ def render_template(output_directory, config_filename, force=False, dry_run=Fals
             os.makedirs(os.path.dirname(output_filename), exist_ok=True)
 
             if os.path.exists(input_filename):
-                shutil.copyfile(input_filename, output_filename)
+                shutil.copy(input_filename, output_filename)
             else:
                 with open(output_filename, "w") as f:
                     f.write(contents[filename])

--- a/qhub/stages/checks.py
+++ b/qhub/stages/checks.py
@@ -298,7 +298,7 @@ def stage_07_kubernetes_services(stage_outputs, config):
         url, verify=False, num_attempts=NUM_ATTEMPTS, timeout=TIMEOUT
     ):
         for i in range(num_attempts):
-            response = requests.get(service_url, verify=verify)
+            response = requests.get(service_url, verify=verify, timeout=timeout)
             if response.status_code < 400:
                 print(f"Attempt {i+1} health check succeded for url={url}")
                 return True

--- a/qhub/utils.py
+++ b/qhub/utils.py
@@ -303,6 +303,44 @@ def modified_environ(*remove: List[str], **update: Dict[str, str]):
         [env.pop(k) for k in remove_after]
 
 
+@contextlib.contextmanager
+def kubernetes_provider_context(kubernetes_credentials: Dict[str, str]):
+    credential_mapping = {
+        "config_path": "KUBE_CONFIG_PATH",
+        "config_context": "KUBE_CTX",
+        "username": "KUBE_USER",
+        "password": "KUBE_PASSWORD",
+        "client_certificate": "KUBE_CLIENT_CERT_DATA",
+        "client_key": "KUBE_CLIENT_KEY_DATA",
+        "cluster_ca_certificate": "KUBE_CLUSTER_CA_CERT_DATA",
+        "host": "KUBE_HOST",
+        "token": "KUBE_TOKEN",
+    }
+
+    credentials = {
+        credential_mapping[k]: v
+        for k, v in kubernetes_credentials.items()
+        if v is not None
+    }
+    with modified_environ(**credentials):
+        yield
+
+
+@contextlib.contextmanager
+def keycloak_provider_context(keycloak_credentials: Dict[str, str]):
+    credential_mapping = {
+        "client_id": "KEYCLOAK_CLIENT_ID",
+        "url": "KEYCLOAK_URL",
+        "username": "KEYCLOAK_USER",
+        "password": "KEYCLOAK_PASSWORD",
+        "realm": "KEYCLOAK_REALM",
+    }
+
+    credentials = {credential_mapping[k]: v for k, v in keycloak_credentials.items()}
+    with modified_environ(**credentials):
+        yield
+
+
 def deep_merge(*args):
     """Deep merge multiple dictionaries.
 


### PR DESCRIPTION
Closes #1092

This is a tricky implementation since we have multiple stages. Several of these stages require credentials kubernetes and keycloak to work. Destroy now works like the following

```
stages: 01, 02, 03, ... 08

for stage in stages:
    stage_ouputs = terraform output (stage)

for stage in reversed(stages):
    terraform destroy 
```

kubernetes and keycloak context are applied correctly along with all needed variables