### PR TITLE
Change AWS Kubenetes provider authentication to use data.eks_cluster instead of exec

### DIFF
--- a/qhub/provider/terraform.py
+++ b/qhub/provider/terraform.py
@@ -257,35 +257,35 @@ def Terraform(**kwargs):
 
 
 @register
-def RequiredProvider(name, **kwargs):
-    return {"terraform": {"required_providers": {name: kwargs}}}
+def RequiredProvider(_name, **kwargs):
+    return {"terraform": {"required_providers": {_name: kwargs}}}
 
 
 @register
-def Provider(name, **kwargs):
-    return {"provider": {name: kwargs}}
+def Provider(_name, **kwargs):
+    return {"provider": {_name: kwargs}}
 
 
 @register
-def TerraformBackend(name, **kwargs):
-    return {"terraform": {"backend": {name: kwargs}}}
+def TerraformBackend(_name, **kwargs):
+    return {"terraform": {"backend": {_name: kwargs}}}
 
 
 @register
-def Variable(name, **kwargs):
-    return {"variable": {name: kwargs}}
+def Variable(_name, **kwargs):
+    return {"variable": {_name: kwargs}}
 
 
 @register
-def Data(resource_type, name, **kwargs):
-    return {"data": {resource_type: {name: kwargs}}}
+def Data(_resource_type, _name, **kwargs):
+    return {"data": {_resource_type: {_name: kwargs}}}
 
 
 @register
-def Resource(resource_type, name, **kwargs):
-    return {"resource": {resource_type: {name: kwargs}}}
+def Resource(_resource_type, _name, **kwargs):
+    return {"resource": {_resource_type: {_name: kwargs}}}
 
 
 @register
-def Output(name, **kwargs):
-    return {"output": {name: kwargs}}
+def Output(_name, **kwargs):
+    return {"output": {_name: kwargs}}

--- a/qhub/stages/tf_objects.py
+++ b/qhub/stages/tf_objects.py
@@ -36,12 +36,14 @@ def QHubKubernetesProvider(qhub_config: Dict):
                 experiments={"manifest_resource": True},
                 host="${data.aws_eks_cluster.default.endpoint}",
                 cluster_ca_certificate="${base64decode(data.aws_eks_cluster.default.certificate_authority[0].data)}",
-                token="${data.aws_eks_cluster_auth.default.token}"
-            )
+                token="${data.aws_eks_cluster_auth.default.token}",
+            ),
         )
     return Provider(
-        "kubernetes", experiments={"manifest_resource": True},
+        "kubernetes",
+        experiments={"manifest_resource": True},
     )
+
 
 def QHubHelmProvider(qhub_config: Dict):
     if qhub_config["provider"] == "aws":
@@ -56,9 +58,9 @@ def QHubHelmProvider(qhub_config: Dict):
                     experiments={"manifest_resource": True},
                     host="${data.aws_eks_cluster.default.endpoint}",
                     cluster_ca_certificate="${base64decode(data.aws_eks_cluster.default.certificate_authority[0].data)}",
-                    token="${data.aws_eks_cluster_auth.default.token}"
-                )
-            )
+                    token="${data.aws_eks_cluster_auth.default.token}",
+                ),
+            ),
         )
     return Provider("helm")
 

--- a/qhub/stages/tf_objects.py
+++ b/qhub/stages/tf_objects.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
-from qhub.provider.terraform import tf_render_objects, TerraformBackend, Provider
+from qhub.provider.terraform import tf_render_objects, TerraformBackend, Provider, Data
+from qhub.utils import deep_merge
 
 
 def QHubAWSProvider(qhub_config: Dict):
@@ -24,22 +25,42 @@ def QHubDigitalOceanProvider(qhub_config: Dict):
 
 
 def QHubKubernetesProvider(qhub_config: Dict):
-    optional_kwargs = {}
     if qhub_config["provider"] == "aws":
-        optional_kwargs["exec"] = {
-            "api_version": "client.authentication.k8s.io/v1alpha1",
-            "args": [
-                "eks",
-                "get-token",
-                "--cluster-name",
-                f"{qhub_config['project_name']}-{qhub_config['namespace']}",
-            ],
-            "command": "aws",
-        }
+        cluster_name = f"{qhub_config['project_name']}-{qhub_config['namespace']}"
 
+        return deep_merge(
+            Data("aws_eks_cluster", "default", name=cluster_name),
+            Data("aws_eks_cluster_auth", "default", name=cluster_name),
+            Provider(
+                "kubernetes",
+                experiments={"manifest_resource": True},
+                host="${data.aws_eks_cluster.default.endpoint}",
+                cluster_ca_certificate="${base64decode(data.aws_eks_cluster.default.certificate_authority[0].data)}",
+                token="${data.aws_eks_cluster_auth.default.token}"
+            )
+        )
     return Provider(
-        "kubernetes", experiments={"manifest_resource": True}, **optional_kwargs
+        "kubernetes", experiments={"manifest_resource": True},
     )
+
+def QHubHelmProvider(qhub_config: Dict):
+    if qhub_config["provider"] == "aws":
+        cluster_name = f"{qhub_config['project_name']}-{qhub_config['namespace']}"
+
+        return deep_merge(
+            Data("aws_eks_cluster", "default", name=cluster_name),
+            Data("aws_eks_cluster_auth", "default", name=cluster_name),
+            Provider(
+                "helm",
+                kubernetes=dict(
+                    experiments={"manifest_resource": True},
+                    host="${data.aws_eks_cluster.default.endpoint}",
+                    cluster_ca_certificate="${base64decode(data.aws_eks_cluster.default.certificate_authority[0].data)}",
+                    token="${data.aws_eks_cluster_auth.default.token}"
+                )
+            )
+        )
+    return Provider("helm")
 
 
 def QHubTerraformState(directory: str, qhub_config: Dict):
@@ -164,6 +185,7 @@ def stage_03_kubernetes_initialize(config):
             [
                 QHubTerraformState("03-kubernetes-initialize", config),
                 QHubKubernetesProvider(config),
+                QHubHelmProvider(config),
             ]
         ),
     }
@@ -175,6 +197,7 @@ def stage_04_kubernetes_ingress(config):
             [
                 QHubTerraformState("04-kubernetes-ingress", config),
                 QHubKubernetesProvider(config),
+                QHubHelmProvider(config),
             ]
         ),
     }
@@ -186,6 +209,7 @@ def stage_05_kubernetes_keycloak(config):
             [
                 QHubTerraformState("05-kubernetes-keycloak", config),
                 QHubKubernetesProvider(config),
+                QHubHelmProvider(config),
             ]
         ),
     }
@@ -207,6 +231,7 @@ def stage_07_kubernetes_services(config):
             [
                 QHubTerraformState("07-kubernetes-services", config),
                 QHubKubernetesProvider(config),
+                QHubHelmProvider(config),
             ]
         ),
     }
@@ -218,6 +243,7 @@ def stage_08_qhub_tf_extensions(config):
             [
                 QHubTerraformState("08-qhub-tf-extensions", config),
                 QHubKubernetesProvider(config),
+                QHubHelmProvider(config),
             ]
         ),
     }

--- a/qhub/template/stages/03-kubernetes-initialize/providers.tf
+++ b/qhub/template/stages/03-kubernetes-initialize/providers.tf
@@ -1,3 +1,0 @@
-provider "helm" {
-
-}

--- a/qhub/template/stages/04-kubernetes-ingress/providers.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/providers.tf
@@ -1,3 +1,0 @@
-provider "helm" {
-
-}

--- a/qhub/template/stages/05-kubernetes-keycloak/providers.tf
+++ b/qhub/template/stages/05-kubernetes-keycloak/providers.tf
@@ -1,3 +1,0 @@
-provider "helm" {
-
-}

--- a/qhub/template/stages/07-kubernetes-services/providers.tf
+++ b/qhub/template/stages/07-kubernetes-services/providers.tf
@@ -1,8 +1,3 @@
-provider "helm" {
-
-}
-
-
 provider "keycloak" {
   tls_insecure_skip_verify = true
 }

--- a/qhub/template/stages/08-qhub-tf-extensions/providers.tf
+++ b/qhub/template/stages/08-qhub-tf-extensions/providers.tf
@@ -1,7 +1,3 @@
-provider "helm" {
-
-}
-
 provider "keycloak" {
   tls_insecure_skip_verify = true
 }


### PR DESCRIPTION
Fixes | Closes | Resolves #1106 

## Changes introduced in this PR:

- this PR changes the aws credentials from being stored and used by each stage to instead being fetched each time the kubernetes provider is used (using data). 

This follows best practices outlined in https://github.com/hashicorp/terraform-provider-kubernetes/tree/main/_examples/eks. Later we may want to adopt this for other clouds.

## Types of changes

These changes should not add or remove any features.

_Put an `x` in the boxes that apply_

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [X] Yes
- [ ] No

