### PR TITLE
Simplify default images

### DIFF
--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -28,7 +28,7 @@ def provision_01_terraform_state(stage_outputs, config):
             terraform_import=True,
             directory=os.path.join(directory, config["provider"]),
             input_vars=input_vars.stage_01_terraform_state(stage_outputs, config),
-            state_imports=state_imports.stage_01_terraform_state(config),
+            state_imports=state_imports.stage_01_terraform_state(stage_outputs, config),
         )
 
 

--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -28,7 +28,7 @@ def provision_01_terraform_state(stage_outputs, config):
             terraform_import=True,
             directory=os.path.join(directory, config["provider"]),
             input_vars=input_vars.stage_01_terraform_state(stage_outputs, config),
-            state_imports=state_imports.stage_01_terraform_state(stage_outputs, config),
+            state_imports=state_imports.stage_01_terraform_state(config),
         )
 
 

--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -170,7 +170,6 @@ DEFAULT_PROFILES = {
                 "cpu_guarantee": 0.75,
                 "mem_limit": "4G",
                 "mem_guarantee": "2.5G",
-                "image": f"quansight/qhub-jupyterlab:{qhub_image_tag}",
             },
         },
         {
@@ -181,7 +180,6 @@ DEFAULT_PROFILES = {
                 "cpu_guarantee": 1.5,
                 "mem_limit": "8G",
                 "mem_guarantee": "5G",
-                "image": f"quansight/qhub-jupyterlab:{qhub_image_tag}",
             },
         },
     ],
@@ -192,7 +190,6 @@ DEFAULT_PROFILES = {
             "worker_memory_limit": "4G",
             "worker_memory": "2.5G",
             "worker_threads": 1,
-            "image": f"quansight/qhub-dask-worker:{qhub_image_tag}",
         },
         "Medium Worker": {
             "worker_cores_limit": 2,
@@ -200,7 +197,6 @@ DEFAULT_PROFILES = {
             "worker_memory_limit": "8G",
             "worker_memory": "5G",
             "worker_threads": 2,
-            "image": f"quansight/qhub-dask-worker:{qhub_image_tag}",
         },
     },
 }

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -304,7 +304,7 @@ class DaskWorkerProfile(Base):
     worker_cores: int
     worker_memory_limit: str
     worker_memory: str
-    image: typing.Optional[bool]
+    image: typing.Optional[str]
 
     class Config:
         extra = "allow"

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -284,7 +284,7 @@ class KubeSpawner(Base):
     cpu_guarantee: int
     mem_limit: str
     mem_guarantee: str
-    image: str
+    image: typing.Optional[str]
 
     class Config:
         extra = "allow"
@@ -304,7 +304,7 @@ class DaskWorkerProfile(Base):
     worker_cores: int
     worker_memory_limit: str
     worker_memory: str
-    image: str
+    image: typing.Optional[bool]
 
     class Config:
         extra = "allow"


### PR DESCRIPTION
Simplifies the default template generated by `qhub init` so that the jupyterlab and dask worker images in `default_images` are actually what is deployed. Previous to this PR there are images that override the default images in the template for `qhub-config.yaml`