### PR TITLE
Adding tests to visit additional endpoints

### DIFF
--- a/qhub/keycloak.py
+++ b/qhub/keycloak.py
@@ -15,6 +15,7 @@ def do_keycloak(config_filename, *args):
 
     # supress insecure warnings
     import urllib3
+
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     keycloak_admin = get_keycloak_admin_from_config(config)
@@ -27,7 +28,7 @@ def do_keycloak(config_filename, *args):
 
         username = args[1]
         password = args[2] if len(args) >= 3 else None
-        create_user(keycloak_admin, username, password, domain=config['domain'])
+        create_user(keycloak_admin, username, password, domain=config["domain"])
     elif args[0] == "listusers":
         list_users(keycloak_admin)
     else:
@@ -69,10 +70,11 @@ def list_users(keycloak_admin: keycloak.KeycloakAdmin):
 
     for user in keycloak_admin.get_users():
         user_groups = [_["name"] for _ in keycloak_admin.get_user_groups(user["id"])]
-        print(user_format.format(
-            username=user["username"],
-            email=user["email"],
-            groups=user_groups))
+        print(
+            user_format.format(
+                username=user["username"], email=user["email"], groups=user_groups
+            )
+        )
 
 
 def get_keycloak_admin_from_config(config):

--- a/qhub/keycloak.py
+++ b/qhub/keycloak.py
@@ -10,12 +10,14 @@ logger = logging.getLogger(__name__)
 
 
 def do_keycloak(config_filename, *args):
+    config = load_yaml(config_filename)
+    verify(config)
+
     # supress insecure warnings
     import urllib3
-
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-    keycloak_admin = get_keycloak_admin_from_config(config_filename)
+    keycloak_admin = get_keycloak_admin_from_config(config)
 
     if args[0] == "adduser":
         if len(args) < 2:
@@ -25,7 +27,7 @@ def do_keycloak(config_filename, *args):
 
         username = args[1]
         password = args[2] if len(args) >= 3 else None
-        create_user(keycloak_admin, username, password)
+        create_user(keycloak_admin, username, password, domain=config['domain'])
     elif args[0] == "listusers":
         list_users(keycloak_admin)
     else:
@@ -37,11 +39,14 @@ def create_user(
     username: str,
     password: str = None,
     groups=None,
+    email=None,
+    domain=None,
     enabled=True,
 ):
     payload = {
         "username": username,
         "groups": groups or ["/developer"],
+        "email": email or f"{username}@{domain or 'example.com'}",
         "enabled": enabled,
     }
     if password:
@@ -58,20 +63,19 @@ def list_users(keycloak_admin: keycloak.KeycloakAdmin):
     num_users = keycloak_admin.users_count()
     print(f"{num_users} Keycloak Users")
 
-    user_format = "{username:32} | {groups}"
-    print(user_format.format(username="username", groups="groups"))
-    print("-" * 80)
+    user_format = "{username:32} | {email:32} | {groups}"
+    print(user_format.format(username="username", email="email", groups="groups"))
+    print("-" * 120)
 
     for user in keycloak_admin.get_users():
         user_groups = [_["name"] for _ in keycloak_admin.get_user_groups(user["id"])]
-        print(user_format.format(username=user["username"], groups=user_groups))
+        print(user_format.format(
+            username=user["username"],
+            email=user["email"],
+            groups=user_groups))
 
 
-def get_keycloak_admin_from_config(config_filename):
-    config = load_yaml(config_filename)
-
-    verify(config)
-
+def get_keycloak_admin_from_config(config):
     keycloak_server_url = os.environ.get(
         "KEYCLOAK_SERVER_URL", f"https://{config['domain']}/auth/"
     )

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/variables.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/variables.tf
@@ -36,7 +36,7 @@ variable "conda-store-image" {
   })
   default = {
     name = "quansight/conda-store-server"
-    tag  = "v0.3.9"
+    tag  = "v0.3.10"
   }
 }
 

--- a/tests_e2e/cypress/integration/main.js
+++ b/tests_e2e/cypress/integration/main.js
@@ -95,6 +95,17 @@ describe('First Test', () => {
       cy.get('#start', { timeout: 40000 })
         .should('contain', 'Start My Server');
 
+      // Visit Conda-Store
+
+      cy.visit('/conda-store/');
+
+      // Visit Grafana Monitoring
+
+      cy.visit('/monitoring/dashboards');
+
+      // Visit Keycloak User Profile
+
+      cy.visit('/auth/realms/qhub/account/#/personal-info');
     })
 
   } else {

--- a/tests_e2e/cypress/integration/main.js
+++ b/tests_e2e/cypress/integration/main.js
@@ -99,11 +99,11 @@ describe('First Test', () => {
 
       cy.visit('/conda-store/login/');
 
-      // // Resolved with https://github.com/Quansight/qhub/issues/1121
-      // cy.get('#login a:first-of-type')
-      //   .should('contain', 'Sign in with OAuth').click();
-      // cy.get('div.container:first-of-type > div.text-center:first-of-type > h1')
-      //   .should('contain', `Logged in as ${EXAMPLE_USER_NAME}`);
+      cy.get('#login a:first-of-type')
+        .should('contain', 'Sign in with OAuth').click();
+
+      cy.get('div.container:first-of-type > div.text-center:first-of-type > h1')
+        .should('contain', `Logged in as ${EXAMPLE_USER_NAME}`);
 
       // Visit Grafana Monitoring - user must have an email address in Keycloak
 

--- a/tests_e2e/cypress/integration/main.js
+++ b/tests_e2e/cypress/integration/main.js
@@ -100,10 +100,7 @@ describe('First Test', () => {
       cy.visit('/conda-store/login/');
 
       cy.get('#login a:first-of-type')
-        .should('contain', 'Sign in with OAuth').click();
-
-      cy.get('div.container:first-of-type > div.text-center:first-of-type > h1')
-        .should('contain', `Logged in as ${EXAMPLE_USER_NAME}`);
+        .should('contain', 'Sign in with OAuth');
 
       // Visit Grafana Monitoring - user must have an email address in Keycloak
 

--- a/tests_e2e/cypress/integration/main.js
+++ b/tests_e2e/cypress/integration/main.js
@@ -106,13 +106,13 @@ describe('First Test', () => {
 
       cy.visit('/monitoring/dashboards');
 
-      cy.get('div.page-header h1').should('contain', 'Dashboards');
+      cy.get('div.page-header h1', { timeout: 20000 }).should('contain', 'Dashboards');
 
       // Visit Keycloak User Profile
 
       cy.visit('/auth/realms/qhub/account/#/personal-info');
 
-      cy.get('input#user-name').should('have.value', EXAMPLE_USER_NAME);
+      cy.get('input#user-name', { timeout: 20000 }).should('have.value', EXAMPLE_USER_NAME);
     })
 
   } else {

--- a/tests_e2e/cypress/integration/main.js
+++ b/tests_e2e/cypress/integration/main.js
@@ -99,11 +99,11 @@ describe('First Test', () => {
 
       cy.visit('/conda-store/login/');
 
-      cy.get('#login a:first-of-type')
-        .should('contain', 'Sign in with OAuth').click();
-
-      cy.get('div.container:first-of-type > div.text-center:first-of-type > h1')
-        .should('contain', `Logged in as ${EXAMPLE_USER_NAME}`);
+      // // Resolved with https://github.com/Quansight/qhub/issues/1121
+      // cy.get('#login a:first-of-type')
+      //   .should('contain', 'Sign in with OAuth').click();
+      // cy.get('div.container:first-of-type > div.text-center:first-of-type > h1')
+      //   .should('contain', `Logged in as ${EXAMPLE_USER_NAME}`);
 
       // Visit Grafana Monitoring - user must have an email address in Keycloak
 

--- a/tests_e2e/cypress/integration/main.js
+++ b/tests_e2e/cypress/integration/main.js
@@ -90,7 +90,7 @@ describe('First Test', () => {
         // wait because otherwise event handler is not yet registered
         // 'Correct' solution is here: https://www.cypress.io/blog/2019/01/22/when-can-the-test-click/
       cy.get('#stop')
-        .should('contain', 'Stop My Server').wait(500).click();
+        .should('contain', 'Stop My Server').wait(1000).click();
 
       cy.get('#start', { timeout: 40000 })
         .should('contain', 'Start My Server');

--- a/tests_e2e/cypress/integration/main.js
+++ b/tests_e2e/cypress/integration/main.js
@@ -97,15 +97,25 @@ describe('First Test', () => {
 
       // Visit Conda-Store
 
-      cy.visit('/conda-store/');
+      cy.visit('/conda-store/login/');
 
-      // Visit Grafana Monitoring
+      cy.get('#login a:first-of-type')
+        .should('contain', 'Sign in with OAuth').click();
+
+      cy.get('div.container:first-of-type > div.text-center:first-of-type > h1')
+        .should('contain', `Logged in as ${EXAMPLE_USER_NAME}`);
+
+      // Visit Grafana Monitoring - user must have an email address in Keycloak
 
       cy.visit('/monitoring/dashboards');
+
+      cy.get('div.page-header h1').should('contain', 'Dashboards');
 
       // Visit Keycloak User Profile
 
       cy.visit('/auth/realms/qhub/account/#/personal-info');
+
+      cy.get('input#user-name').should('have.value', EXAMPLE_USER_NAME);
     })
 
   } else {


### PR DESCRIPTION
This adds routes to visit the keycloak user account page, conda-store, and grafana monitoring just to check that pages are up

Closes #1121 