### PR TITLE
FIX: Fix the Actions checkout bug breaking the tests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.4.0
       - name: documentation quality check
         uses: errata-ai/vale-action@v1.4.0
         with:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -30,7 +30,7 @@ jobs:
           - dask-gateway
     steps:
       - name: 'Checkout Infrastructure'
-        uses: actions/checkout@main
+        uses: actions/checkout@v2.4.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/kubernetes_test.yaml
+++ b/.github/workflows/kubernetes_test.yaml
@@ -39,7 +39,7 @@ jobs:
           echo "GITHUB_HEAD_REF: ${GITHUB_HEAD_REF}"
           echo "GITHUB_REF: ${GITHUB_REF}"
       - name: 'Checkout Infrastructure'
-        uses: actions/checkout@main
+        uses: actions/checkout@v2.4.0
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Set up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v2.4.0
         with:
           python-version: 3.8
 
@@ -35,4 +35,3 @@ jobs:
 # and that the branch release-<version> also points to this tag
 # and that terraform-modules tag release-{version} exists.
 # See https://github.com/Quansight/qhub/issues/544
-

--- a/.github/workflows/test-provider.yaml
+++ b/.github/workflows/test-provider.yaml
@@ -52,7 +52,7 @@ jobs:
           - gitlab-ci
     steps:
       - name: 'Checkout Infrastructure'
-        uses: actions/checkout@main
+        uses: actions/checkout@v2.4.0
       - name: Set up Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
     steps:
       - name: 'Checkout Infrastructure'
-        uses: actions/checkout@main
+        uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
       - name: Set up Python


### PR DESCRIPTION
## Description

The Kubernetes tests are failing:

- https://github.com/Quansight/qhub/runs/5375241426?check_suite_focus=true
- https://github.com/Quansight/qhub/runs/5375171179?check_suite_focus=true
- https://github.com/Quansight/qhub/runs/5375277864?check_suite_focus=true

This has been due to a recent commit pushed on `actions/checkout` that updates the action to Node16 (https://github.com/actions/checkout/commit/8f9e05e482293f862823fcca12d9eddfb3723131).

This has broken our self-hosted Kubernetes tests. This PR hopefully fixes it by pinning the version of checkout action.