### PR TITLE
Add markdown formatter for doc wrapping

### DIFF
--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -4,6 +4,6 @@
 # no configuration file at all. Change the values for non-default
 # behavior.
 #
-wrap = "keep"       # possible values: {"keep", "no", INTEGER}
-number = false      # possible values: {false, true}
+wrap = 180       # possible values: {"keep", "no", INTEGER}
+number = true      # possible values: {false, true}
 end_of_line = "lf"  # possible values: {"lf", "crlf"}

--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,0 +1,9 @@
+# .mdformat.toml
+#
+# This file shows the default values and is equivalent to having
+# no configuration file at all. Change the values for non-default
+# behavior.
+#
+wrap = "keep"       # possible values: {"keep", "no", INTEGER}
+number = false      # possible values: {false, true}
+end_of_line = "lf"  # possible values: {"lf", "crlf"}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,17 @@ repos:
             "--ignore", "DL3013",
             "--ignore", "DL3003",
         ]
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.13
+    hooks:
+    - id: mdformat
+      name: mdformat
+      description: "CommonMark compliant Markdown formatter"
+      entry: mdformat
+      language: python
+      # This is to support a use case where pre-commit runs in Python 2.
+      # Should eventually be removed, at latest when `minimum_pre_commit_version`
+      # is set to 2.0.0.
+      language_version: python3
+      types: [markdown]
+      minimum_pre_commit_version: '1.0.0'


### PR DESCRIPTION
Closes #1113  

## Changes introduced in this PR:

- Add [`mdformat`](https://github.com/executablebooks/mdformat) to wrap doc lines, explicitly added the configuration toml to further change in the default settings. 
- Set wrap line length to 180.

## Types of changes

What types of changes does your PR introduce?

_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [ ] Yes
- [x] No

## Further comments (optional)

Any wrapping will automatically happen when a `.md` file is committed.