### PR TITLE
remove deprecated param `count` from `.cirun.yml`

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -14,5 +14,3 @@ runners:
     workflow: .github/workflows/kubernetes_test.yaml
     # Use Spot Instances for cost savings
     preemptible: false
-    # Number of runners to provision on every trigger on Actions job
-    count: 1


### PR DESCRIPTION
This param is not required anymore. Cirun will automatically provision required number of runners.

> Please remove anything marked as optional that you don't need to fill in.
> Choose one of the keywords preceding to refer to the issue this PR solves, followed by the issue number (e.g Fixes # 666).
> If there is no issue, remove the line. Remove this note after reading.

## Changes introduced in this PR:

-

## Types of changes

What types of changes does your PR introduce?

_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [ ] Yes
- [x] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

Does your contribution include breaking changes or deprecations?
If so have you updated the documentation?

- [ ] Yes, docstrings
- [ ] Yes, main documentation
- [ ] Yes, deprecation notices

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered and more.
