### PR TITLE
Use qhub-bot for keycloak deployment/check

### DIFF
--- a/docs/source/installation/login.md
+++ b/docs/source/installation/login.md
@@ -13,8 +13,7 @@ The `root` Keycloak user is only able to login and manage the Keycloak identity 
 After the initial deployment, it is **highly** recommended that you change the Keycloak `root` user password as soon as you can.
 
 > NOTE: From this point on, the `security.keycloak.initial_root_password` field in `qhub-config.yaml` has no effect. If you redeploy QHub it will not reset the password back to the
-> old one (or anything else that might be in the field in your YAML file). We strongly recommend you replace this value with a dummy value, something like
-> `initial_root_password: ---`.
+> old one (or anything else that might be in the field in your YAML file). We strongly recommend you delete this field.
 
 1. To change the `root` user password, your QHub's instance admin dashboard i.e <https://myqhubsite.com/auth/admin/>, and log in with the password provided.
 

--- a/docs/source/installation/login.md
+++ b/docs/source/installation/login.md
@@ -1,15 +1,20 @@
 # Login
 
-[Keycloak](https://www.keycloak.org/) is the name of the open-source user management software that's automatically deployed within QHub. It's used to store the database of all users in your QHub instance, and can provide connectivity to other services such as GitHub/Auth0 single-sign-on.
+[Keycloak](https://www.keycloak.org/) is the name of the open-source user management software that's automatically deployed within QHub. It's used to store the database of all
+users in your QHub instance, and can provide connectivity to other services such as GitHub/Auth0 single-sign-on.
 
-If you ran `qhub init` to create your `qhub-config.yaml` configuration file as detailed in the [Usage guide](usage.md), you will have been provided with a `random password for Keycloak root user`. **The password will also be visible in the `qhub-config.yaml` file under the `security.keycloak.initial_root_password` field**.
+If you ran `qhub init` to create your `qhub-config.yaml` configuration file as detailed in the [Usage guide](usage.md), you will have been provided with a
+`random password for Keycloak root user`. **The password will also be visible in the `qhub-config.yaml` file under the `security.keycloak.initial_root_password` field**.
 
 The `root` Keycloak user is only able to login and manage the Keycloak identity management section of QHub. It's not a user of the wider QHub data science platform.
 
 ## Change Keycloak root password
 
 After the initial deployment, it is **highly** recommended that you change the Keycloak `root` user password as soon as you can.
-> NOTE: From this point on, the `security.keycloak.initial_root_password` field in `qhub-config.yaml` has no effect. If you redeploy QHub it will not reset the password back to the old one (or anything else that might be in the field in your YAML file). We strongly recommend you delete this field.
+
+> NOTE: From this point on, the `security.keycloak.initial_root_password` field in `qhub-config.yaml` has no effect. If you redeploy QHub it will not reset the password back to the
+> old one (or anything else that might be in the field in your YAML file). We strongly recommend you replace this value with a dummy value, something like
+> `initial_root_password: ---`.
 
 1. To change the `root` user password, your QHub's instance admin dashboard i.e <https://myqhubsite.com/auth/admin/>, and log in with the password provided.
 
@@ -27,10 +32,10 @@ After the initial deployment, it is **highly** recommended that you change the K
 
 ![Keycloak root user page -  account security, update password](../images/keycloak_root_user_update_password.png)
 
-
 ## Adding a QHub user
 
-You will need to add a QHub user in order to log in to your QHub platform. If you have chosen to use GitHub or Auth0 single-sign-on, you must ensure the 'Username' you provide for new users in Keycloak matches the usernames from GitHub or Auth0 respectively.
+You will need to add a QHub user in order to log in to your QHub platform. If you have chosen to use GitHub or Auth0 single-sign-on, you must ensure the 'Username' you provide for
+new users in Keycloak matches the usernames from GitHub or Auth0 respectively.
 
 ### Add user using Keycloak console
 
@@ -50,20 +55,22 @@ The `qhub` realm is selected by default, we strongly recommend leaving it as is.
 
 3. Fill out the three fields, outlined above. These are 'Username', 'Email', and 'Groups'.
 
-Depending on the authentication provider selected ('password', 'GitHub' or 'Auth0'), the values entered into the 'Username' field will differ slightly. The following table outlines those differences:
+Depending on the authentication provider selected ('password', 'GitHub' or 'Auth0'), the values entered into the 'Username' field will differ slightly. The following table outlines
+those differences:
 
-|   | Password  | GitHub  | Auth0   |
-|---|---|---|---|
-| Username | *unique username*  | *GitHub username* | *Email to login with* |
+| | Password | GitHub | Auth0 | |---|---|---|---| | Username | *unique username* | *GitHub username* | *Email to login with* |
 
 Once the 'Username' field is updated, please add a valid email address in the 'Email' field.
+
 > NOTE: Although not required, users may not be able to log into Grafana if this field isn't properly set.
 
-Lastly, associate the user with one or more of the 'Groups'. Out of the box, QHub is deployed with the following groups: 'admin', 'analyst', and 'developer' (see the [Groups](./login.md#groups) section below for more details).
+Lastly, associate the user with one or more of the 'Groups'. Out of the box, QHub is deployed with the following groups: 'admin', 'analyst', and 'developer' (see the
+[Groups](./login.md#groups) section below for more details).
 
 Enter the name you would like for the user then click 'Save'.
 
 Once the user is created, you can set a password.
+
 > NOTE: Not needed for GitHub/Auth0 based authentication.
 
 ![Keycloak add user > credentials tab screenshot - set password](../images/keycloak_user_password.png)
@@ -78,14 +85,13 @@ To make adding users easier for new QHub deployments, there is a QHub command th
 
 > NOTE: This method is primarily used by developers as a quick workaround.
 
-
 Run:
 
 ```shell
 qhub keycloak -c qhub-config.yaml adduser <username> <password>
 ```
 
-This will create a user  `<username>` with the initial password provided. Omit the password completely if you are using GitHub or Auth0.
+This will create a user `<username>` with the initial password provided. Omit the password completely if you are using GitHub or Auth0.
 
 > NOTE: This will also add the user to 'analyst' group.
 
@@ -99,17 +105,16 @@ Click 'Sign in with Keycloak'.
 
 ![QHub - Log in to Keycloak page](../images/keycloak_qhub_login.png)
 
-If you chose GitHub or Auth0 login, click the 'GitHub' button to be taken to a GitHub login page and single-sign-on from there (as shown in the screenshot above). Otherwise, if you choose 'Password` based authentication, enter the username and password you chose when you added a user to QHub above.
+If you chose GitHub or Auth0 login, click the 'GitHub' button to be taken to a GitHub login page and single-sign-on from there (as shown in the screenshot above). Otherwise, if you
+choose 'Password\` based authentication, enter the username and password you chose when you added a user to QHub above.
 
 ## Groups
 
-Groups represent a collection of users that perform similar actions and therefore require the similar permissions. By default, QHub is deployed with the following groups: 'admin', 'developer', 'analyst' and 'viewer'.
+Groups represent a collection of users that perform similar actions and therefore require the similar permissions. By default, QHub is deployed with the following groups: 'admin',
+'developer', 'analyst' and 'viewer'.
 
-| Group | Access to QHub Resources |
-|---|---|
-| 'admin' | Conda-Store Admin <br> Dask Admin <br> Jupyterhub Admin <br> Graphana Admin |
-| 'analyst' | Conda-Store Developer <br> Jupyterhub Developer <br> Graphana Viewer |
-| 'developer' | Conda-Store Developer <br> Dask Developer <br> Jupyterhub Developer <br> Graphana Developer |
+| Group | Access to QHub Resources | |---|---| | 'admin' | Conda-Store Admin <br> Dask Admin <br> Jupyterhub Admin <br> Graphana Admin | | 'analyst' | Conda-Store Developer <br>
+Jupyterhub Developer <br> Graphana Viewer | | 'developer' | Conda-Store Developer <br> Dask Developer <br> Jupyterhub Developer <br> Graphana Developer |
 
 To create new groups or modify (or delete) existing groups, log in as `root` and click 'Groups' on the left-hand side.
 
@@ -121,7 +126,8 @@ To create a new group, click 'New' in the upper-right hand corner. First, give t
 
 ![Keycloak add group form - name field set to conda-store-manager](../images/keycloak_new_group1.png)
 
-Then under 'Role Mapping', add the appriopriate 'Client Roles' as needed; there should be no need to update the 'Realm Roles'. In this example, the new group only has one mapped role however it's possible to attached multiple 'Client Roles' to a single group.
+Then under 'Role Mapping', add the appriopriate 'Client Roles' as needed; there should be no need to update the 'Realm Roles'. In this example, the new group only has one mapped
+role however it's possible to attached multiple 'Client Roles' to a single group.
 
 ![Keycloak group conda-store-manager form - role mappings tab focused with expanded client roles  dropdown](../images/keycloak_new_group2.png)
 

--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -240,7 +240,7 @@ def guided_install(
     )
     username = "root"
     password = (
-        config.get("security").get("keycloak").get("initial_root_password", False)
+        config.get("security", {}).get("keycloak", {}).get("initial_root_password", "")
     )
     if password:
         print(f"Kubecloak master realm username={username} password={password}")

--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import tempfile
 import textwrap
 import subprocess
 
@@ -239,9 +238,13 @@ def guided_install(
     print(
         f"Kubenetes kubeconfig located at file://{stage_outputs['stages/02-infrastructure']['kubeconfig_filename']['value']}"
     )
-    print(
-        f"Kubecloak master realm username={stage_outputs['stages/05-kubernetes-keycloak']['keycloak_credentials']['value']['username']} password=file://{os.path.join(tempfile.gettempdir(), 'QHUB_DEFAULT_PASSWORD')}"
+    username = "root"
+    password = (
+        config.get("security").get("keycloak").get("initial_root_password", False)
     )
+    if password:
+        print(f"Kubecloak master realm username={username} password={password}")
+
     print(
         "Additional administration docs can be found at https://docs.qhub.dev/en/stable/source/admin_guide/"
     )

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -190,7 +190,7 @@ class GitHubAuthentication(Authentication):
 
 
 class Keycloak(Base):
-    initial_root_password: typing.Optional[str] = ""
+    initial_root_password: typing.Optional[str]
     overrides: typing.Optional[typing.Dict]
     realm_display_name: typing.Optional[str]
 
@@ -201,7 +201,7 @@ class Keycloak(Base):
 class Security(Base):
     authentication: Authentication
     shared_users_group: typing.Optional[bool]
-    keycloak: Keycloak
+    keycloak: typing.Optional[Keycloak]
 
 
 # ================ Providers ===============

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -190,7 +190,7 @@ class GitHubAuthentication(Authentication):
 
 
 class Keycloak(Base):
-    initial_root_password: typing.Optional[str]
+    initial_root_password: typing.Optional[str] = ""
     overrides: typing.Optional[typing.Dict]
     realm_display_name: typing.Optional[str]
 

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -201,7 +201,7 @@ class Keycloak(Base):
 class Security(Base):
     authentication: Authentication
     shared_users_group: typing.Optional[bool]
-    keycloak: typing.Optional[Keycloak]
+    keycloak: Keycloak
 
 
 # ================ Providers ===============

--- a/qhub/stages/input_vars.py
+++ b/qhub/stages/input_vars.py
@@ -183,9 +183,9 @@ def stage_06_kubernetes_keycloak_configuration(stage_outputs, config):
 
     return {
         "realm": realm_id,
-        "realm_display_name": config["security"]["keycloak"].get(
-            "realm_display_name", realm_id
-        ),
+        "realm_display_name": config["security"]
+        .get("keycloak", {})
+        .get("realm_display_name", realm_id),
         "authentication": config["security"]["authentication"],
         "keycloak_groups": ["admin", "developer", "analyst"] + users_group,
         "default_groups": ["analyst"] + users_group,

--- a/qhub/stages/input_vars.py
+++ b/qhub/stages/input_vars.py
@@ -160,9 +160,9 @@ def stage_05_kubernetes_keycloak(stage_outputs, config):
         "name": config["project_name"],
         "environment": config["namespace"],
         "endpoint": config["domain"],
-        "initial-root-password": config["security"]["keycloak"][
-            "initial_root_password"
-        ],
+        "initial-root-password": config["security"]["keycloak"].get(
+            "initial_root_password", ""
+        ),
         "overrides": [json.dumps(config["security"]["keycloak"].get("overrides", {}))],
         "node-group": _calculate_note_groups(config)["general"],
     }

--- a/qhub/stages/input_vars.py
+++ b/qhub/stages/input_vars.py
@@ -156,14 +156,20 @@ def stage_04_kubernetes_ingress(stage_outputs, config):
 
 
 def stage_05_kubernetes_keycloak(stage_outputs, config):
+    initial_root_password = (
+        config["security"].get("keycloak", {}).get("initial_root_password", "")
+    )
+    if initial_root_password is None:
+        initial_root_password = ""
+
     return {
         "name": config["project_name"],
         "environment": config["namespace"],
         "endpoint": config["domain"],
-        "initial-root-password": config["security"]["keycloak"].get(
-            "initial_root_password", ""
-        ),
-        "overrides": [json.dumps(config["security"]["keycloak"].get("overrides", {}))],
+        "initial-root-password": initial_root_password,
+        "overrides": [
+            json.dumps(config["security"].get("keycloak", {}).get("overrides", {}))
+        ],
         "node-group": _calculate_note_groups(config)["general"],
     }
 

--- a/qhub/template/stages/05-kubernetes-keycloak/modules/kubernetes/keycloak-helm/outputs.tf
+++ b/qhub/template/stages/05-kubernetes-keycloak/modules/kubernetes/keycloak-helm/outputs.tf
@@ -5,7 +5,7 @@ output "credentials" {
     url       = "https://${var.external-url}"
     client_id = "admin-cli"
     realm     = "master"
-    username  = "root"
-    password  = var.initial-root-password
+    username  = "qhub-bot"
+    password  = var.qhub-bot-password
   }
 }

--- a/qhub/template/stages/05-kubernetes-keycloak/outputs.tf
+++ b/qhub/template/stages/05-kubernetes-keycloak/outputs.tf
@@ -4,6 +4,7 @@ output "keycloak_credentials" {
   value       = module.kubernetes-keycloak-helm.credentials
 }
 
+# At this point this might be redudant, see `qhub-bot-password` in ./modules/kubernetes/keycloak-helm/variables.tf
 output "keycloak_qhub_bot_password" {
   description = "keycloak qhub-bot credentials"
   sensitive   = true


### PR DESCRIPTION
Fixes | Closes | Resolves #1165 

> Please remove anything marked as optional that you don't need to fill in.
> Choose one of the keywords preceding to refer to the issue this PR solves, followed by the issue number (e.g Fixes # 666).
> If there is no issue, remove the line. Remove this note after reading.

## Changes introduced in this PR:

- Use `qhub_bot` keycloak user to perform keycloak validations during the deployment. As opposed to relying on the `root` keycloak user.   

Thanks @danlester walking me through how to resolve this bug!!

## Types of changes

What types of changes does your PR introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [x] Yes - completed
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

Does your contribution include breaking changes or deprecations?
If so have you updated the documentation?

- [ ] Yes, docstrings
- [ ] Yes, main documentation
- [ ] Yes, deprecation notices

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered and more.
