### PR TITLE
Adding ipykernel as default to environment along with ensure conda-store restarted on config change

### DIFF
--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/config/conda_store_config.py
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/config/conda_store_config.py
@@ -13,6 +13,9 @@ c.CondaStore.database_url = "postgresql+psycopg2://${postgres-username}:${postgr
 c.CondaStore.default_uid = 1000
 c.CondaStore.default_gid = 100
 c.CondaStore.default_permissions = "775"
+c.CondaStore.conda_included_packages = [
+    "ipykernel"
+]
 
 c.S3Storage.internal_endpoint = "${minio-service}:9000"
 c.S3Storage.internal_secure = False

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/server.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/server.tf
@@ -79,6 +79,11 @@ resource "kubernetes_deployment" "server" {
         labels = {
           role = "${var.name}-conda-store-server"
         }
+
+        annotations = {
+          # This lets us autorestart when the config changes!
+          "checksum/config-map" = sha256(jsonencode(kubernetes_config_map.conda-store-config.data))
+        }
       }
 
       spec {

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/worker.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/worker.tf
@@ -77,6 +77,11 @@ resource "kubernetes_deployment" "worker" {
         labels = {
           role = "${var.name}-conda-store-worker"
         }
+
+        annotations = {
+          # This lets us autorestart when the conifg changes!
+          "checksum/config-map" = sha256(jsonencode(kubernetes_config_map.conda-store-config.data))
+        }
       }
 
       spec {


### PR DESCRIPTION
Fixes two issues:
 - ipykernel can be missing when a new environment is created
 - conda-store services on redeployment do not load new config without annotation trick