### PR TITLE
Upgrade mrparkers to 3.7.0

### DIFF
--- a/qhub/template/stages/06-kubernetes-keycloak-configuration/main.tf
+++ b/qhub/template/stages/06-kubernetes-keycloak-configuration/main.tf
@@ -1,14 +1,36 @@
 resource "keycloak_realm" "main" {
-  provider = keycloak
 
   realm        = var.realm
   display_name = var.realm_display_name
+  
+  direct_grant_flow    = "direct grant"
+  enabled              = true
+  browser_flow         = "browser"
+  revoke_refresh_token = false
+  user_managed_access  = false
+  ssl_required         = "external"
+  registration_flow    = "registration"
+    
+  refresh_token_max_reuse    = 0
+  reset_credentials_flow     = "reset credentials"
+  client_authentication_flow = "clients"
+  docker_authentication_flow = "docker auth"
+
+  offline_session_max_lifespan_enabled = false
+  
+  web_authn_policy { 
+  }
+  
+  web_authn_passwordless_policy {
+  }
+
 }
 
 resource "keycloak_group" "groups" {
   for_each = var.keycloak_groups
   realm_id = keycloak_realm.main.id
-  name     = each.value
+  name     = each.key
+  attributes = {}
 }
 
 resource "keycloak_default_groups" "default" {

--- a/qhub/template/stages/06-kubernetes-keycloak-configuration/social_auth.tf
+++ b/qhub/template/stages/06-kubernetes-keycloak-configuration/social_auth.tf
@@ -2,6 +2,7 @@ resource "keycloak_authentication_flow" "flow" {
   realm_id    = keycloak_realm.main.id
   alias       = "detect-existing"
   provider_id = "basic-flow"
+  description = ""
 }
 
 resource "keycloak_authentication_execution" "idp-detect-existing-broker-user" {

--- a/qhub/template/stages/06-kubernetes-keycloak-configuration/versions.tf
+++ b/qhub/template/stages/06-kubernetes-keycloak-configuration/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.3.0"
+      version = "3.7.0"
     }
   }
   required_version = ">= 1.0"

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/keycloak-client/versions.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/keycloak-client/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.3.0"
+      version = "3.7.0"
     }
   }
   required_version = ">= 1.0"

--- a/qhub/template/stages/07-kubernetes-services/versions.tf
+++ b/qhub/template/stages/07-kubernetes-services/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.3.0"
+      version = "3.7.0"
     }
   }
   required_version = ">= 1.0"

--- a/qhub/template/stages/08-qhub-tf-extensions/modules/qhubextension/main.tf
+++ b/qhub/template/stages/08-qhub-tf-extensions/modules/qhubextension/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.3.0"
+      version = "3.7.0"
     }
   }
 }

--- a/qhub/template/stages/08-qhub-tf-extensions/versions.tf
+++ b/qhub/template/stages/08-qhub-tf-extensions/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.3.0"
+      version = "3.7.0"
     }
   }
   required_version = ">= 1.0"


### PR DESCRIPTION
I repeatedly saw problems when trying to deploy locally with minikube.

The qhub keycloak realm seemed to fail to be created, causing the subsequent keycloak config to fail ("Realm not found")

This PR seems to make things better, although I'm not sure of the root cause. I also think related Terraform problems can still occur later on in non-keycloak components, but we will have to keep an eye on that separately.

minikube v1.25.2 on Ubuntu 20.04 (amd64)
Using the docker driver
Kubernetes v1.23.3 on Docker 20.10.12 ...
All in a Parallels VM on Mac

## Changes introduced in this PR:

- Upgrade mrparkers/keycloak to 3.7.0
- Set some defaults in keycloak_realm

## Types of changes

What types of changes does your PR introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [x] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

