### PR TITLE
Setting minio storage to by default be same as filesystem size for Conda-Store environments

### DIFF
--- a/qhub/stages/input_vars.py
+++ b/qhub/stages/input_vars.py
@@ -219,7 +219,7 @@ def stage_07_kubernetes_services(stage_outputs, config):
         "node_groups": _calculate_note_groups(config),
         # conda-store
         "conda-store-environments": config["environments"],
-        "conda-store-storage": config["storage"]["conda_store"],
+        "conda-store-filesystem-storage": config["storage"]["conda_store"],
         # jupyterhub
         "cdsdashboards": config["cdsdashboards"],
         "jupyterhub-theme": config["theme"]["jupyterhub"],

--- a/qhub/template/stages/07-kubernetes-services/conda-store.tf
+++ b/qhub/template/stages/07-kubernetes-services/conda-store.tf
@@ -52,7 +52,7 @@ module "conda-store-nfs-mount" {
 
   name         = "conda-store"
   namespace    = var.environment
-  nfs_capacity = var.conda-store-storage
+  nfs_capacity = var.conda-store-filesystem-storage
   nfs_endpoint = module.kubernetes-conda-store-server.endpoint_ip
 
   depends_on = [

--- a/qhub/template/stages/07-kubernetes-services/conda-store.tf
+++ b/qhub/template/stages/07-kubernetes-services/conda-store.tf
@@ -4,9 +4,15 @@ variable "conda-store-environments" {
   default = {}
 }
 
-variable "conda-store-storage" {
-  description = "Conda-Store storage in GB"
+variable "conda-store-filesystem-storage" {
+  description = "Conda-Store storage in GB for filesystem environments that are built"
   type        = string
+}
+
+variable "conda-store-object-storage" {
+  description = "Conda-Store storage in GB for object storage. Conda-Store uses minio for object storage to be cloud agnostic. If empty default is var.conda-store-filesystem-storage value"
+  type        = string
+  default     = null
 }
 
 variable "conda-store-image" {
@@ -31,7 +37,8 @@ module "kubernetes-conda-store-server" {
   external-url = var.endpoint
   realm_id     = var.realm_id
 
-  nfs_capacity      = var.conda-store-storage
+  nfs_capacity      = var.conda-store-filesystem-storage
+  minio_capacity    = coalesce(var.conda-store-object-storage, var.conda-store-filesystem-storage)
   node-group        = var.node_groups.general
   conda-store-image = var.conda-store-image
   environments      = {

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/storage.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/storage.tf
@@ -7,6 +7,8 @@ module "minio" {
 
   node-group = var.node-group
 
+  storage = var.minio_capacity
+
   buckets = [
     "conda-store"
   ]

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/variables.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/conda-store/variables.tf
@@ -9,7 +9,13 @@ variable "namespace" {
 }
 
 variable "nfs_capacity" {
-  description = "Capacity of conda-store deployment"
+  description = "Capacity of conda-store filesystem"
+  type        = string
+  default     = "10Gi"
+}
+
+variable "minio_capacity" {
+  description = "Capacity of conda-store object storage"
   type        = string
   default     = "10Gi"
 }

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/minio/main.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/minio/main.tf
@@ -28,6 +28,11 @@ resource "helm_release" "minio" {
     value = join(" ", var.buckets)
   }
 
+  set {
+    name ="persistence.size"
+    value = var.storage
+  }
+
   values = concat([
     file("${path.module}/values.yaml"),
     jsonencode({

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/minio/variables.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/minio/variables.tf
@@ -11,6 +11,12 @@ variable "namespace" {
 }
 
 
+variable "storage" {
+  description = "Storage size for minio objects"
+  type        = string
+  default     = "10Gi"
+}
+
 variable "buckets" {
   description = "Default available buckets"
   type        = list(string)


### PR DESCRIPTION
Closes #1182 