### PR TITLE
Profilegroups

### DIFF
--- a/docs/source/admin_guide/system_maintenance.md
+++ b/docs/source/admin_guide/system_maintenance.md
@@ -79,6 +79,7 @@ profiles:
   jupyterlab:
     - display_name: Small Instance
       description: Stable environment with 1 cpu / 1 GB ram
+      access: yaml
       groups:
         - admin
       kubespawner_override:
@@ -102,6 +103,7 @@ profiles:
   jupyterlab:
     - display_name: Small Instance
       description: Stable environment with 1 cpu / 1 GB ram
+      access: yaml
       groups:
         - admin
       kubespawner_override:

--- a/docs/source/installation/configuration.md
+++ b/docs/source/installation/configuration.md
@@ -474,6 +474,7 @@ profiles:
   jupyterlab:
     - display_name: Small Instance
       description: Stable environment with 1 cpu / 1 GB ram
+      access: all
       default: true
       kubespawner_override:
         cpu_limit: 1
@@ -482,11 +483,25 @@ profiles:
         mem_guarantee: 1G
     - display_name: Medium Instance
       description: Stable environment with 1.5 cpu / 2 GB ram
+      access: yaml
+      groups:
+        - admin
+        - developers
+      users:
+        - bob
       kubespawner_override:
         cpu_limit: 1.5
         cpu_guarantee: 1.25
         mem_limit: 2G
         mem_guarantee: 2G
+    - display_name: Large Instance
+      description: Stable environment with 2 cpu / 4 GB ram
+      access: keycloak
+      kubespawner_override:
+        cpu_limit: 2
+        cpu_guarantee: 2
+        mem_limit: 4G
+        mem_guarantee: 4G
   dask_worker:
     "Small Worker":
       worker_cores_limit: 1
@@ -500,9 +515,24 @@ profiles:
       worker_memory: 2G
 ```
 
-For each `profiles.jupyterlab` is a named JupyterLab profile. It closely follows the [KubeSpawner](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html) API. The
-only exception is that two keys are added `users` and `groups` which allow restriction of profiles to a given set of groups and users. We recommend using groups to manage profile
-access.
+### JupyterLab Profiles
+
+For each `profiles.jupyterlab` is a named JupyterLab profile.
+
+Use the `kubespawner_override` field to define behavior as per the [KubeSpawner](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html) API.
+
+It is possible to control which users have access to which JupyterLab profiles. Each profile has a field named `access` which can be set to `all` (default if omitted), `yaml`, or
+`keycloak`.
+
+`all` means every user will have access to the profile.
+
+`yaml` means that access is restricted to anyone with their username in the `users` field of the profile or who belongs to a group named in the `groups` field.
+
+`keycloak` means that access is restricted to any user who in Keycloak has either their group(s) or user with the attribute `jupyterlabprofiles` containing this profile name. For
+example, if the user is in a Keycloak group named `developers` which has an attribute `jupyterlabprofiles` set to `Large Instance`, they will have access to the Large Instance
+profile. To specify multiple profiles for one group (or user) delimit their names using `##` - for example, `Large Instance##Another Instance`.
+
+### Dask Profiles
 
 Finally, we allow for configuration of the Dask workers. In general, similar to the JupyterLab instances you only need to configuration the cores and memory.
 
@@ -734,6 +764,7 @@ profiles:
   jupyterlab:
     - display_name: Small Instance
       description: Stable environment with 1 cpu / 1 GB ram
+      access: yaml
       groups:
         - admin
       kubespawner_override:

--- a/docs/source/installation/configuration.md
+++ b/docs/source/installation/configuration.md
@@ -528,8 +528,8 @@ It is possible to control which users have access to which JupyterLab profiles. 
 
 `yaml` means that access is restricted to anyone with their username in the `users` field of the profile or who belongs to a group named in the `groups` field.
 
-`keycloak` means that access is restricted to any user who in Keycloak has either their group(s) or user with the attribute `jupyterlabprofiles` containing this profile name. For
-example, if the user is in a Keycloak group named `developers` which has an attribute `jupyterlabprofiles` set to `Large Instance`, they will have access to the Large Instance
+`keycloak` means that access is restricted to any user who in Keycloak has either their group(s) or user with the attribute `jupyterlab_profiles` containing this profile name. For
+example, if the user is in a Keycloak group named `developers` which has an attribute `jupyterlab_profiles` set to `Large Instance`, they will have access to the Large Instance
 profile. To specify multiple profiles for one group (or user) delimit their names using `##` - for example, `Large Instance##Another Instance`.
 
 ### Dask Profiles

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -41,6 +41,12 @@ class AuthenticationEnum(str, enum.Enum):
     custom = "custom"
 
 
+class AccessEnum(str, enum.Enum):
+    all = "all"
+    yaml = "yaml"
+    keycloak = "keycloak"
+    
+
 class Base(pydantic.BaseModel):
     ...
 
@@ -290,12 +296,22 @@ class KubeSpawner(Base):
 
 
 class JupyterLabProfile(Base):
+    access: AccessEnum = AccessEnum.all
     display_name: str
     description: str
     default: typing.Optional[bool]
     users: typing.Optional[typing.List[str]]
     groups: typing.Optional[typing.List[str]]
     kubespawner_override: typing.Optional[KubeSpawner]
+    
+    @root_validator
+    def only_yaml_can_have_groups_and_users(cls, values):
+        if values["access"] != AccessEnum.yaml:
+            if values.get("users",None) is not None or values.get("groups",None) is not None:
+                raise ValueError(
+                    f"Profile must not contain groups or users fields unless access = yaml"
+                )
+        return values
 
 
 class DaskWorkerProfile(Base):
@@ -313,7 +329,7 @@ class Profiles(Base):
     jupyterlab: typing.List[JupyterLabProfile]
     dask_worker: typing.Dict[str, DaskWorkerProfile]
 
-    @validator("jupyterlab", pre=True)
+    @validator("jupyterlab")
     def check_default(cls, v, values):
         """Check if only one default value is present"""
         default = [attrs["default"] for attrs in v if "default" in attrs]

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -45,7 +45,7 @@ class AccessEnum(str, enum.Enum):
     all = "all"
     yaml = "yaml"
     keycloak = "keycloak"
-    
+
 
 class Base(pydantic.BaseModel):
     ...
@@ -303,13 +303,16 @@ class JupyterLabProfile(Base):
     users: typing.Optional[typing.List[str]]
     groups: typing.Optional[typing.List[str]]
     kubespawner_override: typing.Optional[KubeSpawner]
-    
+
     @root_validator
     def only_yaml_can_have_groups_and_users(cls, values):
         if values["access"] != AccessEnum.yaml:
-            if values.get("users",None) is not None or values.get("groups",None) is not None:
+            if (
+                values.get("users", None) is not None
+                or values.get("groups", None) is not None
+            ):
                 raise ValueError(
-                    f"Profile must not contain groups or users fields unless access = yaml"
+                    "Profile must not contain groups or users fields unless access = yaml"
                 )
         return values
 

--- a/qhub/template/stages/06-kubernetes-keycloak-configuration/main.tf
+++ b/qhub/template/stages/06-kubernetes-keycloak-configuration/main.tf
@@ -31,6 +31,12 @@ resource "keycloak_group" "groups" {
   realm_id = keycloak_realm.main.id
   name     = each.key
   attributes = {}
+  
+  lifecycle {
+    ignore_changes = [
+      attributes,
+    ]
+  }
 }
 
 resource "keycloak_default_groups" "default" {

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyterhub/03-profiles.py
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyterhub/03-profiles.py
@@ -31,8 +31,8 @@ def base_profile_home_mounts(username):
                 "name": "skel",
                 "configMap": {
                     "name": skel_mount["name"],
-                }
-            }
+                },
+            },
         ]
     }
 
@@ -46,7 +46,9 @@ def base_profile_home_mounts(username):
         ]
     }
 
-    MKDIR_OWN_DIRECTORY = "mkdir -p /mnt/{path} && chmod 777 /mnt/{path} && cp -r /etc/skel/. /mnt/{path}"
+    MKDIR_OWN_DIRECTORY = (
+        "mkdir -p /mnt/{path} && chmod 777 /mnt/{path} && cp -r /etc/skel/. /mnt/{path}"
+    )
     command = MKDIR_OWN_DIRECTORY.format(
         path=pvc_home_mount_path.format(username=username)
     )
@@ -316,16 +318,18 @@ def render_profile(profile, username, groups, keycloak_profilenames):
     }
     """
     access = profile.get("access", "all")
-    
+
     if access == "yaml":
         # check that username or groups in allowed groups for profile
         # profile.groups and profile.users can be None or empty lists, or may not be members of profile at all
-        user_not_in_users = username not in set(profile.get('users', []) or [])
-        user_not_in_groups = (set(groups) & set(profile.get('groups', []) or [])) == set()
+        user_not_in_users = username not in set(profile.get("users", []) or [])
+        user_not_in_groups = (
+            set(groups) & set(profile.get("groups", []) or [])
+        ) == set()
         if user_not_in_users and user_not_in_groups:
             return None
     elif access == "keycloak":
-        # Keycloak mapper should provide the 'jupyterlabprofiles' attribute from groups/user
+        # Keycloak mapper should provide the 'jupyterlab_profiles' attribute from groups/user
         if profile.get("display_name", None) not in keycloak_profilenames:
             return None
 
@@ -361,13 +365,19 @@ def render_profiles(spawner):
     # and /developers -> developers
     groups = [os.path.basename(_) for _ in auth_state["oauth_user"]["groups"]]
     spawner.log.error(f"user info: {username} {groups}")
-    
-    keycloak_profilenames = auth_state["oauth_user"].get("jupyterlabprofiles", [])
+
+    keycloak_profilenames = auth_state["oauth_user"].get("jupyterlab_profiles", [])
 
     # fetch available profiles and render additional attributes
     profile_list = z2jh.get_config("custom.profiles")
     return list(
-        filter(None, [render_profile(p, username, groups, keycloak_profilenames) for p in profile_list])
+        filter(
+            None,
+            [
+                render_profile(p, username, groups, keycloak_profilenames)
+                for p in profile_list
+            ],
+        )
     )
 
 

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyterhub/03-profiles.py
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyterhub/03-profiles.py
@@ -316,8 +316,11 @@ def render_profile(profile, username, groups):
     }
     """
     # check that username or groups in allowed groups for profile
-    user_not_in_users = username not in set(profile.get('users', []))
-    user_not_in_groups = (set(groups) & set(profile.get('groups', []))) == set()
+    # profile.groups and profile.users can be None or empty lists, or may not be members of profile at all
+    # if e.g. profile.groups is not set at all, this means no group control is required - every group should be allowed
+    # if profile.groups is None this means to defer to Keycloak group attributes
+    user_not_in_users = username not in set(profile.get('users', []) or [])
+    user_not_in_groups = (set(groups) & set(profile.get('groups', []) or [])) == set()
     if ('users' in profile or 'groups' in profile) and user_not_in_users and user_not_in_groups:
         return None
 

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyterhub/03-profiles.py
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyterhub/03-profiles.py
@@ -326,7 +326,7 @@ def render_profile(profile, username, groups, keycloak_profilenames):
             return None
     elif access == "keycloak":
         # Keycloak mapper should provide the 'jupyterlabprofiles' attribute from groups/user
-        if profile.display_name not in keycloak_profilenames:
+        if profile.get("display_name", None) not in keycloak_profilenames:
             return None
 
     profile = copy.copy(profile)

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/main.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/main.tf
@@ -197,4 +197,5 @@ module "jupyterhub-openid-client" {
     "https://${var.external-url}/hub/oauth_callback",
     var.jupyterhub-logout-redirect-url
   ]
+  jupyterlabprofiles_mapper = true
 }

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/main.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/main.tf
@@ -197,5 +197,5 @@ module "jupyterhub-openid-client" {
     "https://${var.external-url}/hub/oauth_callback",
     var.jupyterhub-logout-redirect-url
   ]
-  jupyterlabprofiles_mapper = true
+  jupyterlab_profiles_mapper = true
 }

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/keycloak-client/main.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/keycloak-client/main.tf
@@ -45,19 +45,19 @@ resource "keycloak_openid_group_membership_protocol_mapper" "main" {
   add_to_userinfo     = true
 }
 
-resource "keycloak_openid_user_attribute_protocol_mapper" "jupyterlabprofiles" {
-  count = var.jupyterlabprofiles_mapper ? 1 : 0
+resource "keycloak_openid_user_attribute_protocol_mapper" "jupyterlab_profiles" {
+  count = var.jupyterlab_profiles_mapper ? 1 : 0
 
   realm_id   = var.realm_id
   client_id  = keycloak_openid_client.main.id
-  name       = "jupyterlabprofiles-mapper"
-  claim_name = "jupyterlabprofiles"
+  name       = "jupyterlab_profiles_mapper"
+  claim_name = "jupyterlab_profiles"
 
   add_to_id_token     = true
   add_to_access_token = true
   add_to_userinfo     = true
-  
-  user_attribute       = "jupyterlabprofiles"
+
+  user_attribute       = "jupyterlab_profiles"
   multivalued          = true
   aggregate_attributes = true
 }

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/keycloak-client/main.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/keycloak-client/main.tf
@@ -45,6 +45,21 @@ resource "keycloak_openid_group_membership_protocol_mapper" "main" {
   add_to_userinfo     = true
 }
 
+resource "keycloak_openid_user_attribute_protocol_mapper" "jupyterlabprofiles" {
+  count = var.jupyterlabprofiles_mapper ? 1 : 0
+
+  realm_id   = var.realm_id
+  client_id  = keycloak_openid_client.main.id
+  name       = "jupyterlabprofiles-mapper"
+  claim_name = "jupyterlabprofiles"
+
+  add_to_id_token     = true
+  add_to_access_token = true
+  add_to_userinfo     = true
+  
+  multivalued          = true
+  aggregate_attributes = true
+}
 
 resource "keycloak_role" "main" {
   for_each = toset(flatten(values(var.role_mapping)))

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/keycloak-client/main.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/keycloak-client/main.tf
@@ -57,6 +57,7 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "jupyterlabprofiles" {
   add_to_access_token = true
   add_to_userinfo     = true
   
+  user_attribute       = "jupyterlabprofiles"
   multivalued          = true
   aggregate_attributes = true
 }

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/keycloak-client/variables.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/keycloak-client/variables.tf
@@ -27,3 +27,10 @@ variable "callback-url-paths" {
   description = "URLs to use for openid callback"
   type        = list(string)
 }
+
+variable "jupyterlabprofiles_mapper" {
+  description = "Create a mapper for jupyterlabprofiles group/user attributes"
+  type        = bool
+  default     = false
+}
+

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/keycloak-client/variables.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/keycloak-client/variables.tf
@@ -28,9 +28,8 @@ variable "callback-url-paths" {
   type        = list(string)
 }
 
-variable "jupyterlabprofiles_mapper" {
-  description = "Create a mapper for jupyterlabprofiles group/user attributes"
+variable "jupyterlab_profiles_mapper" {
+  description = "Create a mapper for jupyterlab_profiles group/user attributes"
   type        = bool
   default     = false
 }
-

--- a/qhub/upgrade.py
+++ b/qhub/upgrade.py
@@ -355,6 +355,32 @@ class Upgrade_0_4_0(UpgradeStep):
         return config
 
 
+class Upgrade_0_4_1(UpgradeStep):
+    version = "0.4.1"
+
+    def _version_specific_upgrade(
+        self, config, start_version, config_filename: pathlib.Path, *args, **kwargs
+    ):
+        """
+        Upgrade jupyterlab profiles.
+        """
+        print("\nUpgrading jupyterlab profiles in order to specify access type:\n")
+
+        profiles_jupyterlab = config.get("profiles", {}).get("jupyterlab", [])
+        for profile in profiles_jupyterlab:
+            name = profile.get("display_name", "")
+
+            if "groups" in profile or "users" in profile:
+                profile["access"] = "yaml"
+            else:
+                profile["access"] = "all"
+
+            print(
+                f"Setting access type of JupyterLab profile {name} to {profile['access']}"
+            )
+        return config
+
+
 __rounded_version__ = ".".join([str(c) for c in rounded_ver_parse(__version__)])
 
 # Manually-added upgrade steps must go above this line

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -34,7 +34,7 @@ def qhub_users_import_json():
         ),
     ],
 )
-def test_upgrade(
+def test_upgrade_4_0(
     old_qhub_config_path_str,
     attempt_fixes,
     expect_upgrade_error,


### PR DESCRIPTION
Fixes #1191 

## Changes introduced in this PR:

`profiles.jupyterlab` in `qhub-config.yaml` now has an `access` field - can be `all`, `keycloak`, `yaml`
- If `yaml`, also specify `groups` and/or `users` fields to restrict access to those users
- If `all` everyone will have access
- If `keycloak` access is granted to users/groups with the Keycloak attribute `jupyterlabprofiles` containing the `display_name` in their lists

Added `qhub upgrade` mechanism for this.

Group attributes are no longer overwritten on non-initial deploys (previously the pre-existing groups would have attributes reset).

## Types of changes

What types of changes does your PR introduce?

_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [x] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

Does your contribution include breaking changes or deprecations?
If so have you updated the documentation?

- [ ] Yes, docstrings
- [x] Yes, main documentation
- [ ] Yes, deprecation notices


