### PR TITLE
add `retrolab` to the base jupyter image

### DIFF
--- a/qhub/template/image/jupyterlab/environment.yaml
+++ b/qhub/template/image/jupyterlab/environment.yaml
@@ -16,6 +16,7 @@ dependencies:
  - jupyterhub==1.5.0
  - nbconvert
  - nbval
+ - retrolab
 
  # jupyterlab extensions
  - dask_labextension >=5.0.0


### PR DESCRIPTION
this pull request adds `retrolab` to the base jupyter environment. `notebook>=7` will deploy a classic version of the notebook that is based on `jupyterlab` components. til then `retrolab` needs to be explicitly installed. likely, we'll remove this change in the future. in the meantime, it allows us to understand the feel or `retrolab` in common workflows.