### PR TITLE
Merge spawner and profile env vars

### DIFF
--- a/.github/workflows/test-provider.yaml
+++ b/.github/workflows/test-provider.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         if: ${{ matrix.provider == 'gcp' }}
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/02-spawner.py
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/02-spawner.py
@@ -32,7 +32,7 @@ if cdsdashboards["enabled"]:
     c.CDSDashboardsConfig.spawn_default_options = False
 
     c.CDSDashboardsConfig.conda_envs = [
-        environment['name'] for _, environment in conda_store_environments.items()
+        environment["name"] for _, environment in conda_store_environments.items()
     ]
 else:
     c.JupyterHub.allow_named_servers = False

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/03-profiles.py
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/03-profiles.py
@@ -319,6 +319,19 @@ def render_profile(profile, username, groups):
         ],
         {},
     )
+
+    # We need to merge any env vars from the spawner with any overrides from the profile
+    # This is mainly to ensure JUPYTERHUB_ANYONE/GROUP is passed through from the spawner
+    # to control dashboard access.
+    envvars_fixed = {**(profile["kubespawner_override"].get("environment", {}))}
+
+    def preserve_envvars(spawner):
+        # This adds in JUPYTERHUB_ANYONE/GROUP rather than overwrite all env vars,
+        # if set in the spawner for a dashboard to control access.
+        return {**envvars_fixed, **spawner.environment}
+
+    profile["kubespawner_override"]["environment"] = preserve_envvars
+
     return profile
 
 


### PR DESCRIPTION
Fixes | Closes | Resolves #1202

## Changes introduced in this PR:

- Merge spawner and profile env vars to ensure dashboard sharing vars are provided to dashboard servers

## Types of changes

What types of changes does your PR introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [x] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No
