### PR TITLE
Add support for terraform overrides in cloud and VPC deployment for Azure

### DIFF
--- a/docs/source/installation/configuration.md
+++ b/docs/source/installation/configuration.md
@@ -720,6 +720,29 @@ ingress:
 
 This is quite useful for pinning the IP Address of the load balancer.
 
+### Deployment inside Virtual Private Network
+
+Using terraform overrides you can also deploy inside a virtual private network.
+
+An example configuration for Azure is given below:
+
+```yaml
+azure:
+  terraform_overrides:
+      private_cluster_enabled: true
+      vnet_subnet_id: '/subscriptions/<subscription_id>/resourceGroups/<resource_group>/providers/Microsoft.Network/virtualNetworks/<vnet-name>/subnets/<subnet-name>'
+  region: Central US
+```
+
+#### Deployment Notes
+
+Deployment inside a virtual network is slightly different from deploying inside a public network,
+as the name suggests, since its a virtual private network, you need to be inside the network to
+able to deploy and access QHub. One way to achieve this is by creating a Virtual Machine inside
+the virtual network, just select the virtual network and subnet name under the networking
+settings of your cloud provider while creating the VM and then follow the usual deployment
+instructions as you would deploy from your local machine.
+
 # Full configuration example
 
 ```yaml

--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -237,6 +237,7 @@ class DigitalOceanProvider(Base):
     region: str
     kubernetes_version: str
     node_groups: typing.Dict[str, NodeGroup]
+    terraform_overrides: typing.Any
 
 
 class GoogleCloudPlatformProvider(Base):
@@ -246,6 +247,7 @@ class GoogleCloudPlatformProvider(Base):
     availability_zones: typing.Optional[typing.List[str]]  # Genuinely optional
     kubernetes_version: str
     node_groups: typing.Dict[str, NodeGroup]
+    terraform_overrides: typing.Any
 
 
 class AzureProvider(Base):
@@ -253,6 +255,7 @@ class AzureProvider(Base):
     kubernetes_version: str
     node_groups: typing.Dict[str, NodeGroup]
     storage_account_postfix: str
+    terraform_overrides: typing.Any
 
 
 class AmazonWebServicesProvider(Base):
@@ -260,6 +263,7 @@ class AmazonWebServicesProvider(Base):
     availability_zones: typing.Optional[typing.List[str]]
     kubernetes_version: str
     node_groups: typing.Dict[str, NodeGroup]
+    terraform_overrides: typing.Any
 
 
 class LocalProvider(Base):

--- a/qhub/stages/input_vars.py
+++ b/qhub/stages/input_vars.py
@@ -47,6 +47,7 @@ def stage_02_infrastructure(stage_outputs, config):
             "kubeconfig_filename": os.path.join(
                 tempfile.gettempdir(), "QHUB_KUBECONFIG"
             ),
+            **config.get("do", {}).get("terraform_overrides", {}),
         }
     elif config["provider"] == "gcp":
         return {
@@ -67,6 +68,7 @@ def stage_02_infrastructure(stage_outputs, config):
             "kubeconfig_filename": os.path.join(
                 tempfile.gettempdir(), "QHUB_KUBECONFIG"
             ),
+            **config.get("gcp", {}).get("terraform_overrides", {}),
         }
     elif config["provider"] == "azure":
         return {
@@ -80,6 +82,7 @@ def stage_02_infrastructure(stage_outputs, config):
             ),
             "resource_group_name": f'{config["project_name"]}-{config["namespace"]}',
             "node_resource_group_name": f'{config["project_name"]}-{config["namespace"]}-node-resource-group',
+            **config.get("azure", {}).get("terraform_overrides", {}),
         }
     elif config["provider"] == "aws":
         return {
@@ -99,6 +102,7 @@ def stage_02_infrastructure(stage_outputs, config):
             "kubeconfig_filename": os.path.join(
                 tempfile.gettempdir(), "QHUB_KUBECONFIG"
             ),
+            **config.get("aws", {}).get("terraform_overrides", {}),
         }
     else:
         return {}

--- a/qhub/template/stages/02-infrastructure/azure/modules/kubernetes/main.tf
+++ b/qhub/template/stages/02-infrastructure/azure/modules/kubernetes/main.tf
@@ -9,9 +9,11 @@ resource "azurerm_kubernetes_cluster" "main" {
 
   # Azure requires that a new, non-existent Resource Group is used, as otherwise the provisioning of the Kubernetes Service will fail.
   node_resource_group = var.node_resource_group_name
+  private_cluster_enabled = var.private_cluster_enabled
 
   kubernetes_version = var.kubernetes_version
   default_node_pool {
+    vnet_subnet_id = var.vnet_subnet_id
     name                = var.node_groups[0].name
     node_count          = 1
     vm_size             = var.node_groups[0].instance_type

--- a/qhub/template/stages/02-infrastructure/azure/modules/kubernetes/variables.tf
+++ b/qhub/template/stages/02-infrastructure/azure/modules/kubernetes/variables.tf
@@ -34,3 +34,15 @@ variable "node_groups" {
   description = "Node pools to add to Azure Kubernetes Cluster"
   type        = list(map(any))
 }
+
+variable "vnet_subnet_id" {
+  description = "The ID of a Subnet where the Kubernetes Node Pool should exist. Changing this forces a new resource to be created."
+  type        = string
+  default     = null
+}
+
+variable "private_cluster_enabled" {
+  description = "Should this Kubernetes Cluster have its API server only exposed on internal IP addresses? This provides a Private IP Address for the Kubernetes API on the Virtual Network where the Kubernetes Cluster is located. Defaults to false. Changing this forces a new resource to be created."
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
Add support for terraform overrides in cloud and VPC deployment for Azure

Resolves partially #1211 for Azure

> Please remove anything marked as optional that you don't need to fill in.
> Choose one of the keywords preceding to refer to the issue this PR solves, followed by the issue number (e.g Fixes # 666).
> If there is no issue, remove the line. Remove this note after reading.

## Changes introduced in this PR:

- Add ability to override terraform for Azure to be able to provide `vnet_subnet_id` and `private_cluster_enabled`

## Types of changes

What types of changes does your PR introduce?

_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

Manually deployed on Azure

### Requires testing

- [ ] Yes
- [x] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

Does your contribution include breaking changes or deprecations?
If so have you updated the documentation?

- [ ] Yes, docstrings
- [ ] Yes, main documentation
- [ ] Yes, deprecation notices

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered and more.
