### PR TITLE
Github actions broken for new repos: rename github secrets so github will be happy again

### DIFF
--- a/docs/source/installation/setup.md
+++ b/docs/source/installation/setup.md
@@ -204,8 +204,8 @@ automatically generates the deployment modules for the infrastructure. To do tha
 a github personal access token via [these instructions](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). The token needs permissions to
 create a repo and create secrets on the repo. At the moment we don't have the permissions well scoped out so to be on the safe side enable all permissions.
 
-- `GITHUB_USERNAME`: GitHub username
-- `GITHUB_TOKEN`: GitHub-generated token
+- `USERNAME_GITHUB`: GitHub username
+- `TOKEN_GITHUB`: GitHub-generated token
 
 </details>
 

--- a/qhub/cli/initialize.py
+++ b/qhub/cli/initialize.py
@@ -34,7 +34,7 @@ def create_init_subcommand(subparser):
     subparser.add_argument(
         "--repository-auto-provision",
         action="store_true",
-        help="Attempt to automatically provision repository. For github it requires environment variables GITHUB_USERNAME, GITHUB_TOKEN",
+        help="Attempt to automatically provision repository. For github it requires environment variables USERNAME_GITHUB, TOKEN_GITHUB",
     )
     subparser.add_argument(
         "--auth-auto-provision",

--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -470,7 +470,7 @@ def github_auto_provision(config, owner, repo):
             }:
                 github.update_secret(owner, repo, name, os.environ[name])
         github.update_secret(
-            owner, repo, "REPOSITORY_ACCESS_TOKEN", os.environ["GITHUB_TOKEN"]
+            owner, repo, "REPOSITORY_ACCESS_TOKEN", os.environ["TOKEN_GITHUB"]
         )
     except requests.exceptions.HTTPError as he:
         raise ValueError(

--- a/qhub/provider/cicd/github.py
+++ b/qhub/provider/cicd/github.py
@@ -14,7 +14,7 @@ from qhub.utils import pip_install_qhub
 def github_request(url, method="GET", json=None):
     GITHUB_BASE_URL = "https://api.github.com/"
 
-    for name in ("GITHUB_USERNAME", "GITHUB_TOKEN"):
+    for name in ("USERNAME_GITHUB", "TOKEN_GITHUB"):
         if os.environ.get(name) is None:
             raise ValueError(
                 f"environment variable={name} is required for github automation"
@@ -30,7 +30,7 @@ def github_request(url, method="GET", json=None):
         f"{GITHUB_BASE_URL}{url}",
         json=json,
         auth=requests.auth.HTTPBasicAuth(
-            os.environ["GITHUB_USERNAME"], os.environ["GITHUB_TOKEN"]
+            os.environ["USERNAME_GITHUB"], os.environ["TOKEN_GITHUB"]
         ),
     )
     response.raise_for_status()
@@ -65,7 +65,7 @@ def get_repository(owner, repo):
 
 
 def create_repository(owner, repo, description, homepage, private=True):
-    if owner == os.environ.get("GITHUB_USERNAME"):
+    if owner == os.environ.get("USERNAME_GITHUB"):
         github_request(
             "user/repos",
             method="POST",
@@ -92,7 +92,7 @@ def create_repository(owner, repo, description, homepage, private=True):
 
 def gha_env_vars(config):
     env_vars = {
-        "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}",
+        "TOKEN_GITHUB": "${{ secrets.TOKEN_GITHUB }}",
     }
 
     if os.environ.get("QHUB_GH_BRANCH"):
@@ -286,7 +286,7 @@ def gen_qhub_linter(config):
     step4_envs = {
         "PR_NUMBER": GHA_job_steps_extras(__root__="${{ github.event.number }}"),
         "REPO_NAME": GHA_job_steps_extras(__root__="${{ github.repository }}"),
-        "GITHUB_TOKEN": GHA_job_steps_extras(
+        "TOKEN_GITHUB": GHA_job_steps_extras(
             __root__="${{ secrets.REPOSITORY_ACCESS_TOKEN }}"
         ),
     }

--- a/qhub/provider/cicd/linter.py
+++ b/qhub/provider/cicd/linter.py
@@ -90,7 +90,7 @@ def comment_on_pr(config):
     owner, repo_name = os.environ["REPO_NAME"].split("/")
     pr_id = os.environ["PR_NUMBER"]
 
-    token = os.environ["GITHUB_TOKEN"]
+    token = os.environ["TOKEN_GITHUB"]
     url = f"https://api.github.com/repos/{owner}/{repo_name}/issues/{pr_id}/comments"
 
     payload = {"body": message}


### PR DESCRIPTION
Github no longer allows repository secrets that begin with `GITHUB_` : 
![image](https://user-images.githubusercontent.com/49161327/166515597-bd0ad58b-e0dc-4164-9524-9d288d25b8b1.png)

This fixes that