### PR TITLE
Fix missing region from AWS provider

### DIFF
--- a/qhub/stages/tf_objects.py
+++ b/qhub/stages/tf_objects.py
@@ -27,10 +27,11 @@ def QHubDigitalOceanProvider(qhub_config: Dict):
 def QHubKubernetesProvider(qhub_config: Dict):
     if qhub_config["provider"] == "aws":
         cluster_name = f"{qhub_config['project_name']}-{qhub_config['namespace']}"
-
+        # The AWS provider needs to be added, as we are using aws related resources #1254
         return deep_merge(
             Data("aws_eks_cluster", "default", name=cluster_name),
             Data("aws_eks_cluster_auth", "default", name=cluster_name),
+            Provider("aws", region=qhub_config["amazon_web_services"]["region"]),
             Provider(
                 "kubernetes",
                 experiments={"manifest_resource": True},


### PR DESCRIPTION
Fixes | Closes | Resolves #1228 #1254

## Changes introduced in this PR:

- Add AWS provider configuration to terraform state files where Kubernetes provider was initialized;
- This adds the missing region variable, explained in #1254 

## Types of changes

What types of changes does your PR introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [ ] Yes
- [x] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

## Further comments (optional)

This is a simple change to be added and does not require further testing as I was able to successfully deploy Qhub on AWS without the env variable workaround after this. The strange part is that we didn't see this error during 0.4.0/0.4.1 pre-release testing.