### PR TITLE
Add prefect token var to CI when needed

### DIFF
--- a/docs/source/admin_guide/prefect.md
+++ b/docs/source/admin_guide/prefect.md
@@ -18,9 +18,9 @@ prefect:
 There are a bunch of components in getting Prefect working for you, here is a brief description of them:
 
 1. Create a free Prefect cloud account here: https://cloud.prefect.io/
-2. Create a Service Account and an API key for the same and add this to the CI secrets as `TF_VAR_prefect_token`:
-   - In GitHub: Set it in Secrets (https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository)
-   - In GitLab: Set it as Variables (https://docs.gitlab.com/ee/ci/variables/#gitlab-cicd-variables)
+2. Create a Service Account and an API key for the same and add this to the CI secrets as `QHUB_SECRET_PREFECT_TOKEN`:
+   - In GitHub: Set it in [Secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository)
+   - In GitLab: Set it as [Variables](https://docs.gitlab.com/ee/ci/variables/#gitlab-cicd-variables)
 3. Create a project in the Prefect Cloud Dashboard. Alternatively from CLI:
 
 ```

--- a/qhub/provider/cicd/github.py
+++ b/qhub/provider/cicd/github.py
@@ -99,7 +99,7 @@ def gha_env_vars(config):
         env_vars["QHUB_GH_BRANCH"] = "${{ secrets.QHUB_GH_BRANCH }}"
 
     # This assumes that the user is using the omitting sensitive values configuration for the token.
-    if config["prefect"].get("enabled", False):
+    if config.get("prefect", {}).get("enabled", False):
         env_vars[
             "QHUB_SECRET_prefect_token"
         ] = "${{ secrets.QHUB_SECRET_PREFECT_TOKEN }}"

--- a/qhub/provider/cicd/github.py
+++ b/qhub/provider/cicd/github.py
@@ -98,6 +98,12 @@ def gha_env_vars(config):
     if os.environ.get("QHUB_GH_BRANCH"):
         env_vars["QHUB_GH_BRANCH"] = "${{ secrets.QHUB_GH_BRANCH }}"
 
+    # This assumes that the user is using the omitting sensitive values configuration for the token.
+    if config["prefect"].get("enabled", False):
+        env_vars[
+            "QHUB_SECRET_prefect_token"
+        ] = "${{ secrets.QHUB_SECRET_PREFECT_TOKEN }}"
+
     if config["provider"] == "aws":
         env_vars["AWS_ACCESS_KEY_ID"] = "${{ secrets.AWS_ACCESS_KEY_ID }}"
         env_vars["AWS_SECRET_ACCESS_KEY"] = "${{ secrets.AWS_SECRET_ACCESS_KEY }}"


### PR DESCRIPTION
Fixes | Closes | Resolves #878 

## Changes introduced in this PR:

- Add a secret key to CI/CD config on GH, for when Prefect token is required
- Changed Prefect token env var syntax from `TF_VAR_prefect_token` to `QHUB_SECRET_PREFECT_TOKEN`

The reason why I changed the syntax lies in the fact we now support the direct inclusion of variables to terraform which was not feasible by Terraform infrastructure only in 0.3.+. Also, by using the `QHUB_SECRET` prefix, we are indeed using the [omitting sensitive values](https://docs.qhub.dev/en/stable/source/installation/configuration.html?#omitting-sensitive-values) settings from this type of information.

## Types of changes

What types of changes does your PR introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [ ] Yes
- [x] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [ ] No

## Documentation

Does your contribution include breaking changes or deprecations?
If so have you updated the documentation?

- [ ] Yes, docstrings
- [x] Yes, main documentation
- [ ] Yes, deprecation notices

## Further comments (optional)

This (Prefect) still needs to be fully tested to validate which configuration might need to be managed since the 0.4.0 changes took place. #1217 
