### PR TITLE
Added documentation for getting in touch about QHub

### DIFF
--- a/docs/source/reference/getting_in_touch.md
+++ b/docs/source/reference/getting_in_touch.md
@@ -1,0 +1,21 @@
+# Getting In Touch
+
+## Gitter
+
+Come join the community on [Gitter](https://gitter.im/Quansight/qhub)!
+
+## Discussions
+
+[GitHub Discussions](https://github.com/Quansight/qhub/discussions) are a great
+place to discuss longer questions about QHub.
+
+## Bugs
+
+Bugs are tracked on the [GitHub issue
+tracker](https://github.com/Quansight/qhub/issues).
+
+## Professional Support
+
+If you're looking for professional support, [contact
+Quansight](https://www.quansight.com/) with your project requirements - we'll
+work together to find a solution that fits your needs.

--- a/docs/source/reference/index.md
+++ b/docs/source/reference/index.md
@@ -1,0 +1,7 @@
+# Reference
+
+```{toctree}
+:maxdepth: 2
+
+getting_in_touch.md
+```


### PR DESCRIPTION
Partially addresses #1076.

## Changes introduced in this PR:

- Added a "References" directory to the documentation, one of the four main sections in the Diataxis documentation framework. See [notion](https://www.notion.so/quansightlabs/Diataxis-documentation-09152841232f4f0289feaec1c258c200) for more information.
- Added a `getting_in_touch.md` section with links to some of the places the QHub team can be contacted.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [x] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [ ] Yes
- [x] No

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered and more.
