### PR TITLE
feat: add r-studio to jupyterlab image

### DIFF
--- a/qhub/template/image/jupyterlab/environment.yaml
+++ b/qhub/template/image/jupyterlab/environment.yaml
@@ -51,6 +51,10 @@ dependencies:
  # vscode
  - code-server >= 3.2
 
+ # rstudio
+ - r-base
+ - r-tidyverse
+
  - pip:
      # vscode jupyterlab launcher
      - git+https://github.com/betatim/vscode-binder


### PR DESCRIPTION
Fixes #896 


## Changes introduced in this PR:

- Add R-Studio

## Types of changes

What types of changes does your PR introduce?

_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [X] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [X] No

## Additional comments

With this, both [RStudio](https://www.rstudio.com/) and [IRKernel](https://irkernel.github.io/) are installed by default, so the user can use either the Jupyter interface or the RStudio interface.

For some R packages, there is no corresponding conda-forge package yet, in that case, take a look at https://github.com/binder-examples/r. Note that these two approaches cannot be combined, so we cannot install R packages via Conda and via an `install.R` file at the same time.