### PR TITLE
Overrides default value for dask-labextension

### DIFF
--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyterlab/overrides.json
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/jupyterhub/files/jupyterlab/overrides.json
@@ -1,3 +1,5 @@
 {
-
+    "dask-labextension:plugin": {
+        "browserDashboardCheck": true
+    }
 }


### PR DESCRIPTION
Fixes | Closes | Resolves #1326 

## Changes introduced in this PR:

- Updates the default value of `browserDashboardCheck` from `False` to `True`
This will guarantee that every spawned profile has the fix for the dask-gateway and dask-labextension dashboard issue.

## Types of changes

What types of changes does your PR introduce?

_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [x] Maintance related task.

## Testing

### Requires testing

- [ ] Yes
- [x] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

## Further comments (optional)
This is a very simple addition to address the remaining needs of #1012 