### PR TITLE
Increase the default instance sizes

### DIFF
--- a/docs/source/installation/configuration.md
+++ b/docs/source/installation/configuration.md
@@ -464,8 +464,8 @@ Control the amount of storage allocated to shared filesystem.
 
 ```yaml
 storage:
-  conda_store: 20Gi
-  shared_filesystem: 10Gi
+  conda_store: 200Gi
+  shared_filesystem: 200Gi
 ```
 
 ## Profiles

--- a/docs/source/installation/existing.md
+++ b/docs/source/installation/existing.md
@@ -82,10 +82,10 @@ carefully:
   - `Node IAM Role` must be the IAM role described proceeding
 - "Node Group compute configuration"
   - `Instance type`
-    - The recommended minimum vCPU and memory for a `general` node is 4 vCPU / 16 GB RAM
-    - The recommended minimum vCPU and memory for a `user` and `worker` node is 2 vCPU / 8 GB RAM
+    - The recommended minimum vCPU and memory for a `general` node is 8 vCPU / 32 GB RAM
+    - The recommended minimum vCPU and memory for a `user` and `worker` node is 4 vCPU / 16 GB RAM
   - `Disk size`
-    - The recommended minimum is 20 GB for the attached EBS (block-strage)
+    - The recommended minimum is 200 GB for the attached EBS (block-strage)
 - "Node Group scaling configuration"
   - `Minimum size` and `Maximum size` of 1 for the `general` node group
 - "Node Group subnet configuration"
@@ -172,36 +172,36 @@ local:
 profiles:
   jupyterlab:
   - display_name: Small Instance
-    description: Stable environment with 1 cpu / 4 GB ram
-    default: true
-    kubespawner_override:
-      cpu_limit: 1
-      cpu_guarantee: 0.75
-      mem_limit: 4G
-      mem_guarantee: 2.5G
-      image: quansight/qhub-jupyterlab:v0.3.13
-  - display_name: Medium Instance
     description: Stable environment with 2 cpu / 8 GB ram
+    default: true
     kubespawner_override:
       cpu_limit: 2
       cpu_guarantee: 1.5
       mem_limit: 8G
       mem_guarantee: 5G
       image: quansight/qhub-jupyterlab:v0.3.13
+  - display_name: Medium Instance
+    description: Stable environment with 4 cpu / 16 GB ram
+    kubespawner_override:
+      cpu_limit: 4
+      cpu_guarantee: 3
+      mem_limit: 16G
+      mem_guarantee: 10G
+      image: quansight/qhub-jupyterlab:v0.3.13
   dask_worker:
     Small Worker:
-      worker_cores_limit: 1
-      worker_cores: 0.75
-      worker_memory_limit: 4G
-      worker_memory: 2.5G
-      worker_threads: 1
-      image: quansight/qhub-dask-worker:v0.3.13
-    Medium Worker:
       worker_cores_limit: 2
       worker_cores: 1.5
       worker_memory_limit: 8G
       worker_memory: 5G
       worker_threads: 2
+      image: quansight/qhub-dask-worker:v0.3.13
+    Medium Worker:
+      worker_cores_limit: 4
+      worker_cores: 3
+      worker_memory_limit: 16G
+      worker_memory: 10G
+      worker_threads: 4
       image: quansight/qhub-dask-worker:v0.3.13
 environments:
   environment-dask.yaml:

--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -39,7 +39,7 @@ BASE_CONFIGURATION = {
         "jupyterlab": f"quansight/qhub-jupyterlab:{qhub_image_tag}",
         "dask_worker": f"quansight/qhub-dask-worker:{qhub_image_tag}",
     },
-    "storage": {"conda_store": "60Gi", "shared_filesystem": "100Gi"},
+    "storage": {"conda_store": "200Gi", "shared_filesystem": "200Gi"},
     "theme": {
         "jupyterhub": {
             "hub_title": None,
@@ -120,9 +120,9 @@ DIGITAL_OCEAN = {
     "region": "nyc3",
     "kubernetes_version": "PLACEHOLDER",
     "node_groups": {
-        "general": {"instance": "g-4vcpu-16gb", "min_nodes": 1, "max_nodes": 1},
-        "user": {"instance": "g-2vcpu-8gb", "min_nodes": 1, "max_nodes": 5},
-        "worker": {"instance": "g-2vcpu-8gb", "min_nodes": 1, "max_nodes": 5},
+        "general": {"instance": "g-8vcpu-32gb", "min_nodes": 1, "max_nodes": 1},
+        "user": {"instance": "g-4vcpu-16gb", "min_nodes": 1, "max_nodes": 5},
+        "worker": {"instance": "g-4vcpu-16gb", "min_nodes": 1, "max_nodes": 5},
     },
 }
 # Digital Ocean image slugs are listed here https://slugs.do-api.dev/
@@ -132,9 +132,9 @@ GOOGLE_PLATFORM = {
     "region": "us-central1",
     "kubernetes_version": "PLACEHOLDER",
     "node_groups": {
-        "general": {"instance": "n1-standard-4", "min_nodes": 1, "max_nodes": 1},
-        "user": {"instance": "n1-standard-2", "min_nodes": 0, "max_nodes": 5},
-        "worker": {"instance": "n1-standard-2", "min_nodes": 0, "max_nodes": 5},
+        "general": {"instance": "n1-standard-8", "min_nodes": 1, "max_nodes": 1},
+        "user": {"instance": "n1-standard-4", "min_nodes": 0, "max_nodes": 5},
+        "worker": {"instance": "n1-standard-4", "min_nodes": 0, "max_nodes": 5},
     },
 }
 
@@ -143,13 +143,13 @@ AZURE = {
     "kubernetes_version": "PLACEHOLDER",
     "node_groups": {
         "general": {
-            "instance": "Standard_D4_v3",
+            "instance": "Standard_D8_v3",
             "min_nodes": 1,
             "max_nodes": 1,
         },
-        "user": {"instance": "Standard_D2_v2", "min_nodes": 0, "max_nodes": 5},
+        "user": {"instance": "Standard_D4_v3", "min_nodes": 0, "max_nodes": 5},
         "worker": {
-            "instance": "Standard_D2_v2",
+            "instance": "Standard_D4_v3",
             "min_nodes": 0,
             "max_nodes": 5,
         },
@@ -163,9 +163,9 @@ AMAZON_WEB_SERVICES = {
     "region": "us-west-2",
     "kubernetes_version": "PLACEHOLDER",
     "node_groups": {
-        "general": {"instance": "m5.xlarge", "min_nodes": 1, "max_nodes": 1},
-        "user": {"instance": "m5.large", "min_nodes": 1, "max_nodes": 5},
-        "worker": {"instance": "m5.large", "min_nodes": 1, "max_nodes": 5},
+        "general": {"instance": "m5.2xlarge", "min_nodes": 1, "max_nodes": 1},
+        "user": {"instance": "m5.xlarge", "min_nodes": 1, "max_nodes": 5},
+        "worker": {"instance": "m5.xlarge", "min_nodes": 1, "max_nodes": 5},
     },
 }
 
@@ -173,18 +173,8 @@ DEFAULT_PROFILES = {
     "jupyterlab": [
         {
             "display_name": "Small Instance",
-            "description": "Stable environment with 1 cpu / 4 GB ram",
-            "default": True,
-            "kubespawner_override": {
-                "cpu_limit": 1,
-                "cpu_guarantee": 0.75,
-                "mem_limit": "4G",
-                "mem_guarantee": "2.5G",
-            },
-        },
-        {
-            "display_name": "Medium Instance",
             "description": "Stable environment with 2 cpu / 8 GB ram",
+            "default": True,
             "kubespawner_override": {
                 "cpu_limit": 2,
                 "cpu_guarantee": 1.5,
@@ -192,21 +182,31 @@ DEFAULT_PROFILES = {
                 "mem_guarantee": "5G",
             },
         },
+        {
+            "display_name": "Medium Instance",
+            "description": "Stable environment with 4 cpu / 16 GB ram",
+            "kubespawner_override": {
+                "cpu_limit": 4,
+                "cpu_guarantee": 3,
+                "mem_limit": "16G",
+                "mem_guarantee": "10G",
+            },
+        },
     ],
     "dask_worker": {
         "Small Worker": {
-            "worker_cores_limit": 1,
-            "worker_cores": 0.75,
-            "worker_memory_limit": "4G",
-            "worker_memory": "2.5G",
-            "worker_threads": 1,
-        },
-        "Medium Worker": {
             "worker_cores_limit": 2,
             "worker_cores": 1.5,
             "worker_memory_limit": "8G",
             "worker_memory": "5G",
             "worker_threads": 2,
+        },
+        "Medium Worker": {
+            "worker_cores_limit": 4,
+            "worker_cores": 3,
+            "worker_memory_limit": "16G",
+            "worker_memory": "10G",
+            "worker_threads": 4,
         },
     },
 }


### PR DESCRIPTION
Closes #1111 and https://github.com/nebari-dev/nebari/issues/37

## Changes introduced in this PR:

- Doubled the profile sizes for the small and medium workers.
- Doubled the node sizes across the board for all cloud providers
- Increased the default conda-store storage to 200G, and the shared filesystem to 200G as well
- Updated documentation to reflect these changes

## Types of changes

What types of changes does your PR introduce?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [x] Other (please describe): Increases the default node sizes and worker profile sizes across the board.

## Testing

### Requires testing

- [x] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

Does your contribution include breaking changes or deprecations?
If so have you updated the documentation?

- [ ] Yes, docstrings
- [x] Yes, main documentation
- [ ] Yes, deprecation notices

## Further comments (optional)

After talking to several people on the nebari team and checking some existing deployment profiles, I've doubled the node and profile sizes across the board. If others feel that we should increase these defaults further, I'm happy to make that change.