### PR TITLE
Bump qhub-dask version to 0.4.3

### DIFF
--- a/qhub/template/image/Dockerfile.dask-worker
+++ b/qhub/template/image/Dockerfile.dask-worker
@@ -6,7 +6,7 @@ RUN /opt/scripts/install-apt-minimal.sh
 
 COPY scripts/fix-permissions /opt/scripts/fix-permissions
 
-ENV CONDA_VERSION py37_4.10.3
+ENV CONDA_VERSION py38_4.10.3
 ENV CONDA_SHA256 a1a7285dea0edc430b2bc7951d89bb30a2a1b32026d2a7b02aacaaa95cf69c7c
 SHELL ["/bin/bash", "-c"]
 

--- a/qhub/template/image/Dockerfile.dask-worker
+++ b/qhub/template/image/Dockerfile.dask-worker
@@ -7,7 +7,7 @@ RUN /opt/scripts/install-apt-minimal.sh
 COPY scripts/fix-permissions /opt/scripts/fix-permissions
 
 ENV CONDA_VERSION py38_4.10.3
-ENV CONDA_SHA256 a1a7285dea0edc430b2bc7951d89bb30a2a1b32026d2a7b02aacaaa95cf69c7c
+ENV CONDA_SHA256 935d72deb16e42739d69644977290395561b7a6db059b316958d97939e9bdf3d
 SHELL ["/bin/bash", "-c"]
 
 ENV PATH=/opt/conda/bin:${PATH}:/opt/scripts

--- a/qhub/template/image/dask-worker/environment.yaml
+++ b/qhub/template/image/dask-worker/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
  # dask
- - qhub-dask==0.3.13
+ - qhub-dask==0.4.3

--- a/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/dask-gateway/variables.tf
+++ b/qhub/template/stages/07-kubernetes-services/modules/kubernetes/services/dask-gateway/variables.tf
@@ -31,8 +31,8 @@ variable "gateway-image" {
     tag  = string
   })
   default = {
-    name = "daskgateway/dask-gateway-server"
-    tag  = "0.9.0"
+    name = "ghcr.io/dask/dask-gateway-server"
+    tag  = "2022.4.0"
   }
 }
 
@@ -43,8 +43,8 @@ variable "controller-image" {
     tag  = string
   })
   default = {
-    name = "daskgateway/dask-gateway-server"
-    tag  = "0.9.0"
+    name = "ghcr.io/dask/dask-gateway-server"
+    tag  = "2022.4.0"
   }
 }
 
@@ -55,8 +55,8 @@ variable "cluster-image" {
     tag  = string
   })
   default = {
-    name = "daskgateway/dask-gateway"
-    tag  = "0.9.0"
+    name = "ghcr.io/dask/dask-gateway"
+    tag  = "2022.4.0"
   }
 }
 

--- a/qhub/utils.py
+++ b/qhub/utils.py
@@ -34,7 +34,7 @@ AZURE_ENV_DOCS = (
 
 qhub_image_tag = f"v{__version__}"
 pip_install_qhub = f"pip install qhub=={__version__}"
-qhub_dask_version = "0.4.0"
+qhub_dask_version = "0.4.3"
 
 QHUB_GH_BRANCH = os.environ.get("QHUB_GH_BRANCH", "")
 if QHUB_GH_BRANCH:


### PR DESCRIPTION
Closes #1296 

## Changes introduced in this PR:

- Bumped `qhub-dask` to version `0.4.3`, which includes `distributed==2022.04.2` and `dask-gateway==2022.4.0`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [x] Other (please describe): Enhancement

## Testing

### Requires testing

- [ ] Yes
- [x] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

Github workflows for testing new versions of qhub-dask before they get released to conda-forge will be addressing in #1339. Until then, testing was carried out on an existing qhub deployment, see the discussion at https://github.com/conda-forge/qhub-dask-feedstock/pull/14 for more information.

## Documentation

Does your contribution include breaking changes or deprecations?
If so have you updated the documentation?

- [ ] Yes, docstrings
- [x] Yes, main documentation
- [ ] Yes, deprecation notices