### PR TITLE
Drop support for python 3.7 in dask environment

### DIFF
--- a/docs/source/installation/configuration.md
+++ b/docs/source/installation/configuration.md
@@ -642,7 +642,7 @@ environments:
       - conda-forge
       - defaults
     dependencies:
-      - python=3.7
+      - python=3.8
       - ipykernel
       - ipywidgets
       - qhub-dask==||QHUB_VERSION||
@@ -656,7 +656,7 @@ environments:
       - conda-forge
       - defaults
     dependencies:
-      - python=3.7
+      - python=3.8
       - ipykernel
       - ipywidgets
       - qhub-dask==||QHUB_VERSION||
@@ -880,7 +880,7 @@ environments:
       - conda-forge
       - defaults
     dependencies:
-      - python=3.7
+      - python=3.8
       - ipykernel
       - ipywidgets
       - qhub-dask==||QHUB_VERSION||
@@ -894,7 +894,7 @@ environments:
       - conda-forge
       - defaults
     dependencies:
-      - python=3.7
+      - python=3.8
       - ipykernel
       - ipywidgets
       - qhub-dask==||QHUB_VERSION||

--- a/docs/source/user_guide/environments.md
+++ b/docs/source/user_guide/environments.md
@@ -11,7 +11,7 @@ environments:
       - conda-forge
       - defaults
     dependencies:
-      - python=3.7
+      - python=3.8
       - ipykernel
       - ipywidgets
       - qhub-dask==||QHUB_VERSION||


### PR DESCRIPTION
Closes #1345.

## Changes introduced in this PR:

Both the dask-worker environment and the default dask client environment don't have a pinned python version, it's only dictated by the current requirements of `qhub-dask`. So the only updates necessary are documentation changes.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [x] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [ ] Yes
- [x] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

Does your contribution include breaking changes or deprecations?
If so have you updated the documentation?

- [ ] Yes, docstrings
- [ ] Yes, main documentation
- [ ] Yes, deprecation notices