### PR TITLE
Improvements in the QHub Cost estimate tool

### DIFF
--- a/qhub/cli/cost.py
+++ b/qhub/cli/cost.py
@@ -35,7 +35,7 @@ def create_cost_subcommand(subparser):
         default="USD",
     )
     subparser.add_argument(
-        "-ct",
+        "-cc",
         "--compare",
         help="Compare the cost report to a previously generated report",
         required=False,

--- a/qhub/cli/cost.py
+++ b/qhub/cli/cost.py
@@ -1,3 +1,4 @@
+import ast
 import logging
 
 from qhub.cost import infracost_report
@@ -13,8 +14,15 @@ def create_cost_subcommand(subparser):
         help="Pass the path of your stages directory generated after rendering QHub configurations before deployment",
         required=False,
     )
+    subparser.add_argument(
+        "-d",
+        "--dashboard",
+        default="True",
+        help="Enable the cost dashboard",
+        required=False,
+    )
     subparser.set_defaults(func=handle_cost_report)
 
 
 def handle_cost_report(args):
-    infracost_report(args.path)
+    infracost_report(args.path, ast.literal_eval(args.dashboard))

--- a/qhub/cli/cost.py
+++ b/qhub/cli/cost.py
@@ -27,8 +27,17 @@ def create_cost_subcommand(subparser):
         help="Specify the path of the file to store the cost report",
         required=False,
     )
+    subparser.add_argument(
+        "-c",
+        "--currency",
+        help="Specify the currency code to use in the cost report",
+        required=False,
+        default="USD",
+    )
     subparser.set_defaults(func=handle_cost_report)
 
 
 def handle_cost_report(args):
-    infracost_report(args.path, ast.literal_eval(args.dashboard), args.file)
+    infracost_report(
+        args.path, ast.literal_eval(args.dashboard), args.file, args.currency
+    )

--- a/qhub/cli/cost.py
+++ b/qhub/cli/cost.py
@@ -21,8 +21,14 @@ def create_cost_subcommand(subparser):
         help="Enable the cost dashboard",
         required=False,
     )
+    subparser.add_argument(
+        "-f",
+        "--file",
+        help="Specify the path of the file to store the cost report",
+        required=False,
+    )
     subparser.set_defaults(func=handle_cost_report)
 
 
 def handle_cost_report(args):
-    infracost_report(args.path, ast.literal_eval(args.dashboard))
+    infracost_report(args.path, ast.literal_eval(args.dashboard), args.file)

--- a/qhub/cli/cost.py
+++ b/qhub/cli/cost.py
@@ -34,10 +34,20 @@ def create_cost_subcommand(subparser):
         required=False,
         default="USD",
     )
+    subparser.add_argument(
+        "-ct",
+        "--compare",
+        help="Compare the cost report to a previously generated report",
+        required=False,
+    )
     subparser.set_defaults(func=handle_cost_report)
 
 
 def handle_cost_report(args):
     infracost_report(
-        args.path, ast.literal_eval(args.dashboard), args.file, args.currency
+        args.path,
+        ast.literal_eval(args.dashboard),
+        args.file,
+        args.currency,
+        args.compare,
     )

--- a/qhub/cost.py
+++ b/qhub/cost.py
@@ -84,7 +84,20 @@ def _enable_infracost_dashboard():
         return False
 
 
-def infracost_report(path):
+def _disable_infracost_dashboard():
+    """
+    Disable infracost dashboard
+    """
+    try:
+        subprocess.check_output(
+            ["infracost", "configure", "set", "enable_dashboard", "false"]
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def infracost_report(path, dashboard):
     """
     Generate a report of the infracost cost of the given path
     args:
@@ -94,7 +107,11 @@ def infracost_report(path):
         path = os.path.join(os.getcwd(), "stages")
 
     if _check_infracost() and _check_infracost_api_key():
-        _enable_infracost_dashboard()
+        if not dashboard:
+            _disable_infracost_dashboard()
+        else:
+            _enable_infracost_dashboard()
+
         if not os.path.exists(path):
             logger.error("Deployment is not available")
         else:
@@ -143,7 +160,8 @@ def infracost_report(path):
                 console = Console()
                 console.print(cost_table)
                 console.print(resource_table)
-                console.print(f"Access the dashboard here: {data['shareUrl']}\n")
+                if dashboard:
+                    console.print(f"Access the dashboard here: {data['shareUrl']}\n")
                 console.print(Markdown(INFRACOST_NOTE))
             else:
                 logger.error(

--- a/qhub/cost.py
+++ b/qhub/cost.py
@@ -97,25 +97,34 @@ def _disable_infracost_dashboard():
         return False
 
 
-def infracost_report(path, dashboard):
+def infracost_report(path, dashboard, file):
     """
     Generate a report of the infracost cost of the given path
     args:
         path: path to the qhub stages directory
     """
+    # If path is not provided, use the current directory with `stages` subdirectory
     if not path:
         path = os.path.join(os.getcwd(), "stages")
 
+    # Checks if infracost is installed and an API key is configured
     if _check_infracost() and _check_infracost_api_key():
         if not dashboard:
             _disable_infracost_dashboard()
         else:
             _enable_infracost_dashboard()
 
+        # Check if the deployment is available on the given path
         if not os.path.exists(path):
             logger.error("Deployment is not available")
         else:
             data = _run_infracost(path)
+
+            # If a user has asked for a JSON file, download it
+            if file:
+                # Convert data to JSON and save it to the given file
+                with open(file, "w") as f:
+                    json.dump(data, f)
             if data:
                 cost_table = Table(title="Cost Breakdown")
                 cost_table.add_column(

--- a/qhub/cost.py
+++ b/qhub/cost.py
@@ -47,6 +47,19 @@ def _check_infracost_api_key():
         return False
 
 
+def _set_currency_code(currency_code):
+    """
+    Specify the currency code for infracost
+    """
+    try:
+        subprocess.check_output(
+            ["infracost", "configure", "set", "currency", currency_code]
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
 def _run_infracost(path):
     """
     Run infracost on the given path and return the JSON output
@@ -97,7 +110,7 @@ def _disable_infracost_dashboard():
         return False
 
 
-def infracost_report(path, dashboard, file):
+def infracost_report(path, dashboard, file, currency_code):
     """
     Generate a report of the infracost cost of the given path
     args:
@@ -109,6 +122,7 @@ def infracost_report(path, dashboard, file):
 
     # Checks if infracost is installed and an API key is configured
     if _check_infracost() and _check_infracost_api_key():
+        _set_currency_code(currency_code)
         if not dashboard:
             _disable_infracost_dashboard()
         else:
@@ -131,7 +145,7 @@ def infracost_report(path, dashboard, file):
                     "Name", justify="right", style="cyan", no_wrap=True
                 )
                 cost_table.add_column(
-                    "Cost ($)", justify="right", style="cyan", no_wrap=True
+                    "Cost", justify="right", style="cyan", no_wrap=True
                 )
 
                 cost_table.add_row("Total Monthly Cost", data["totalMonthlyCost"])


### PR DESCRIPTION
Fixes #1351

## Changes introduced in this PR:

- Provide an option (`--dashboard` or `-d`) to user to check if they need a shareable link of the dashboard. Defaults to `True` in case not provided.

- Provide an option (`--file` or `-f`) to user to download infracost reports locally.

- Provide an option (`--currency` or `-c`) to user to customize the infracost report currency with preferred [ISO 4217 currency](https://en.wikipedia.org/wiki/ISO_4217#Active_codes)

- Provide an option (`--compare` or `-ct`) to user to compare deployment costs across different deployments and present them a new table with the breakdown along with a shareable link of the dashboard