### PR TITLE
Update Ingress overrides behaviour

### DIFF
--- a/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
@@ -59,14 +59,15 @@ resource "kubernetes_service" "main" {
   wait_for_load_balancer = true
 
   metadata {
-    name      = "${var.name}-traefik-ingress"
-    namespace = var.namespace
+    name        = "${var.name}-traefik-ingress"
+    namespace   = var.namespace
+    annotations = var.load-balancer-annotations
   }
 
   spec {
-    selector = merge({
+    selector = {
       "app.kubernetes.io/component" = "traefik-ingress"
-    }, var.load-balancer-annotations)
+    }
 
     port {
       name        = "http"

--- a/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/variables.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/variables.tf
@@ -67,9 +67,6 @@ variable "load-balancer-ip" {
 
 variable "load-balancer-annotations" {
   description = "Annotations for the load balancer"
-  type = map(object({
-    key   = string
-    value = string
-  }))
-  default = null
+  type        = map(string)
+  default     = null
 }

--- a/qhub/template/stages/04-kubernetes-ingress/variables.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/variables.tf
@@ -49,9 +49,6 @@ variable "load-balancer-ip" {
 
 variable "load-balancer-annotations" {
   description = "Annotations for the load balancer"
-  type = map(object({
-    key   = string
-    value = string
-  }))
-  default = null
+  type        = map(string)
+  default     = null
 }


### PR DESCRIPTION
related to #1418 

## Changes introduced in this PR:

- FIxed incorrect assignment of load balancer annotations, from `kubernetes_service.spec.selector` to `kubernetes_service.metadata` according to [documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects) and vide [example](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer) 
- Updated variable `type`, from `map(object({...}))` to `map(string)`, as `object` [restricts the variable structure to match object specification. ](https://www.terraform.io/language/expressions/type-constraints#object)

## Types of changes

What types of changes does your PR introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [x] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [x] No

## Documentation

Does your contribution include breaking changes or deprecations?
If so have you updated the documentation?

- [ ] Yes, docstrings
- [ ] Yes, main documentation
- [ ] Yes, deprecation notices

## Further comments (optional)

Tested with local deployment and inspect that the proper values were set:
```
[terraform]:   # module.kubernetes-ingress.kubernetes_service.main will be created
[terraform]:   + resource "kubernetes_service" "main" {
[terraform]:       + id                     = (known after apply)
[terraform]:       + status                 = (known after apply)
[terraform]:       + wait_for_load_balancer = true
[terraform]: 
[terraform]:       + metadata {
[terraform]:           + annotations      = {
[terraform]:               + "networking.gke.io/internal-load-balancer-subnet" = "pre-existing-subnet"
[terraform]:               + "networking.gke.io/load-balancer-type"            = "Internal"
[terraform]:             }
[terraform]:           + generation       = (known after apply)
[terraform]:           + name             = "qhub-traefik-ingress"
[terraform]:           + namespace        = "dev"
[terraform]:           + resource_version = (known after apply)
[terraform]:           + uid              = (known after apply)
[terraform]:         }

```
