### PR TITLE
Add option to disable tls certificate

### DIFF
--- a/qhub/schema.py
+++ b/qhub/schema.py
@@ -14,6 +14,7 @@ class CertificateEnum(str, enum.Enum):
     letsencrypt = "lets-encrypt"
     selfsigned = "self-signed"
     existing = "existing"
+    disabled = "disabled"
 
 
 class TerraformStateEnum(str, enum.Enum):

--- a/qhub/stages/input_vars.py
+++ b/qhub/stages/input_vars.py
@@ -181,17 +181,20 @@ def _calculate_note_groups(config):
 
 
 def stage_04_kubernetes_ingress(stage_outputs, config):
+    cert_type = config["certificate"]["type"]
+    cert_details = {"certificate-service": cert_type}
+    if cert_type == "lets-encrypt":
+        cert_details["acme-email"] = config["certificate"]["acme_email"]
+        cert_details["acme-server"] = config["certificate"]["acme_server"]
+
     return {
-        "name": config["project_name"],
-        "environment": config["namespace"],
-        "node_groups": _calculate_note_groups(config),
-        "enable-certificates": (config["certificate"]["type"] == "lets-encrypt"),
-        "acme-email": config["certificate"].get("acme_email"),
-        "acme-server": config["certificate"].get("acme_server"),
-        "certificate-secret-name": config["certificate"]["secret_name"]
-        if config["certificate"]["type"] == "existing"
-        else None,
-        **config.get("ingress", {}).get("terraform_overrides", {}),
+        **{
+            "name": config["project_name"],
+            "environment": config["namespace"],
+            "node_groups": _calculate_note_groups(config),
+            **config.get("ingress", {}).get("terraform_overrides", {}),
+        },
+        **cert_details,
     }
 
 

--- a/qhub/template/stages/04-kubernetes-ingress/main.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/main.tf
@@ -5,7 +5,7 @@ module "kubernetes-ingress" {
 
   node-group = var.node_groups.general
 
-  enable-certificates       = var.enable-certificates
+  certificate-service       = var.certificate-service
   acme-email                = var.acme-email
   acme-server               = var.acme-server
   certificate-secret-name   = var.certificate-secret-name

--- a/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
@@ -4,7 +4,7 @@ locals {
     "--entrypoints.minio.http.tls.certResolver=default",
   ]
   self_signed = "${var.certificate-service}" == "self-signed" ? local.default_cert : []
-  existing = "${var.certificate-service}" == "existing" ? local.default_cert : []
+  existing    = "${var.certificate-service}" == "existing" ? local.default_cert : []
   letsencrypt = "${var.certificate-service}" == "lets-encrypt" ? [
     "--entrypoints.websecure.http.tls.certResolver=letsencrypt",
     "--entrypoints.minio.http.tls.certResolver=letsencrypt",
@@ -13,7 +13,7 @@ locals {
     "--certificatesresolvers.letsencrypt.acme.storage=acme.json",
     "--certificatesresolvers.letsencrypt.acme.caserver=${var.acme-server}",
   ] : []
-  disabled = "${var.certificate-service}" == "disabled" ? [] : []
+  disabled        = "${var.certificate-service}" == "disabled" ? [] : []
   add-certificate = coalesce(local.self_signed, local.existing, local.letsencrypt, local.disabled)
 }
 

--- a/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
@@ -3,18 +3,20 @@ locals {
     "--entrypoints.websecure.http.tls.certResolver=default",
     "--entrypoints.minio.http.tls.certResolver=default",
   ]
-  self_signed = "${var.certificate-service}" == "self-signed" ? local.default_cert : []
-  existing    = "${var.certificate-service}" == "existing" ? local.default_cert : []
-  letsencrypt = "${var.certificate-service}" == "lets-encrypt" ? [
-    "--entrypoints.websecure.http.tls.certResolver=letsencrypt",
-    "--entrypoints.minio.http.tls.certResolver=letsencrypt",
-    "--certificatesresolvers.letsencrypt.acme.tlschallenge",
-    "--certificatesresolvers.letsencrypt.acme.email=${var.acme-email}",
-    "--certificatesresolvers.letsencrypt.acme.storage=acme.json",
-    "--certificatesresolvers.letsencrypt.acme.caserver=${var.acme-server}",
-  ] : []
-  disabled        = "${var.certificate-service}" == "disabled" ? [] : []
-  add-certificate = coalesce(local.self_signed, local.existing, local.letsencrypt, local.disabled)
+  certificate-settings = {
+    lets-encrypt = [
+      "--entrypoints.websecure.http.tls.certResolver=letsencrypt",
+      "--entrypoints.minio.http.tls.certResolver=letsencrypt",
+      "--certificatesresolvers.letsencrypt.acme.tlschallenge",
+      "--certificatesresolvers.letsencrypt.acme.email=${var.acme-email}",
+      "--certificatesresolvers.letsencrypt.acme.storage=acme.json",
+      "--certificatesresolvers.letsencrypt.acme.caserver=${var.acme-server}",
+    ]
+    self-signed = local.default_cert
+    existing    = local.default_cert
+    disabled    = []
+  }
+  add-certificate = local.certificate-settings[var.certificate-service]
 }
 
 

--- a/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
@@ -3,9 +3,9 @@ locals {
     "--entrypoints.websecure.http.tls.certResolver=default",
     "--entrypoints.minio.http.tls.certResolver=default",
   ]
-  default = "${var.certificate-service}" == "default" ? local.default_cert : []
+  self_signed = "${var.certificate-service}" == "self-signed" ? local.default_cert : []
   existing = "${var.certificate-service}" == "existing" ? local.default_cert : []
-  letsencrypt = "${var.certificate-service}" == "letsencrypt" ? [
+  letsencrypt = "${var.certificate-service}" == "lets-encrypt" ? [
     "--entrypoints.websecure.http.tls.certResolver=letsencrypt",
     "--entrypoints.minio.http.tls.certResolver=letsencrypt",
     "--certificatesresolvers.letsencrypt.acme.tlschallenge",
@@ -13,7 +13,8 @@ locals {
     "--certificatesresolvers.letsencrypt.acme.storage=acme.json",
     "--certificatesresolvers.letsencrypt.acme.caserver=${var.acme-server}",
   ] : []
-  add-certificate = coalesce(local.default, local.letsencrypt, [])
+  disabled = "${var.certificate-service}" == "disabled" ? [] : []
+  add-certificate = coalesce(local.self_signed, local.existing, local.letsencrypt, local.disabled)
 }
 
 

--- a/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
@@ -1,3 +1,20 @@
+locals {
+  default = "${var.certificate-service}" == "default" ? [
+    "--entrypoints.websecure.http.tls.certResolver=default",
+    "--entrypoints.minio.http.tls.certResolver=default",
+  ] : ""
+  letsencrypt = "${var.certificate-service}" == "letsencrypt" ? [
+    "--entrypoints.websecure.http.tls.certResolver=letsencrypt",
+    "--entrypoints.minio.http.tls.certResolver=letsencrypt",
+    "--certificatesresolvers.letsencrypt.acme.tlschallenge",
+    "--certificatesresolvers.letsencrypt.acme.email=${var.acme-email}",
+    "--certificatesresolvers.letsencrypt.acme.storage=acme.json",
+    "--certificatesresolvers.letsencrypt.acme.caserver=${var.acme-server}",
+  ] : ""
+  add-certificate = coalesce(local.default, local.letsencrypt, [""])
+}
+
+
 resource "kubernetes_service_account" "main" {
   metadata {
     name      = "${var.name}-traefik-ingress"
@@ -238,22 +255,8 @@ resource "kubernetes_deployment" "main" {
             # Enable debug logging. Useful to work out why something might not be
             # working. Fetch logs of the pod.
             "--log.level=${var.loglevel}",
-            ], var.enable-certificates ? [
-            "--entrypoints.websecure.http.tls.certResolver=letsencrypt",
-            "--entrypoints.minio.http.tls.certResolver=letsencrypt",
-            "--certificatesresolvers.letsencrypt.acme.tlschallenge",
-            "--certificatesresolvers.letsencrypt.acme.email=${var.acme-email}",
-            "--certificatesresolvers.letsencrypt.acme.storage=acme.json",
-            "--certificatesresolvers.letsencrypt.acme.caserver=${var.acme-server}",
-            ] : [
-            # ideally we could write "--entrypoints.websecure.http.tls={}"
-            # but this doesn't seem to work?
-            # since all we want to do is trigger traefik to generate a certificate
-            # the downside of specifying this is you will see error messages
-            # in the traefik logs like "... uses a non-existent resolver: default"
-            "--entrypoints.websecure.http.tls.certResolver=default",
-            "--entrypoints.minio.http.tls.certResolver=default",
-          ])
+            ], var.add-certificate
+          )
 
           port {
             name           = "http"

--- a/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
@@ -1,8 +1,10 @@
 locals {
-  default = "${var.certificate-service}" == "default" ? [
+  default_cert = [
     "--entrypoints.websecure.http.tls.certResolver=default",
     "--entrypoints.minio.http.tls.certResolver=default",
-  ] : ""
+  ]
+  default = "${var.certificate-service}" == "default" ? local.default_cert : []
+  existing = "${var.certificate-service}" == "existing" ? local.default_cert : []
   letsencrypt = "${var.certificate-service}" == "letsencrypt" ? [
     "--entrypoints.websecure.http.tls.certResolver=letsencrypt",
     "--entrypoints.minio.http.tls.certResolver=letsencrypt",
@@ -10,8 +12,8 @@ locals {
     "--certificatesresolvers.letsencrypt.acme.email=${var.acme-email}",
     "--certificatesresolvers.letsencrypt.acme.storage=acme.json",
     "--certificatesresolvers.letsencrypt.acme.caserver=${var.acme-server}",
-  ] : ""
-  add-certificate = coalesce(local.default, local.letsencrypt, [""])
+  ] : []
+  add-certificate = coalesce(local.default, local.letsencrypt, [])
 }
 
 

--- a/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
@@ -255,7 +255,7 @@ resource "kubernetes_deployment" "main" {
             # Enable debug logging. Useful to work out why something might not be
             # working. Fetch logs of the pod.
             "--log.level=${var.loglevel}",
-            ], var.add-certificate
+            ], local.add-certificate
           )
 
           port {

--- a/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/variables.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/variables.tf
@@ -66,7 +66,6 @@ variable "load-balancer-annotations" {
   default     = null
 }
 
-# current options: "default", "letsencrypt", "" (i.e. disabled)
 variable "certificate-service" {
   description = "The certificate service to use"
   type        = string

--- a/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/variables.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/variables.tf
@@ -35,11 +35,6 @@ variable "loglevel" {
   default     = "WARN"
 }
 
-variable "enable-certificates" {
-  description = "Enable certificates"
-  default     = false
-}
-
 variable "acme-email" {
   description = "ACME server email"
   default     = "costrouchov@quansight.com"
@@ -69,4 +64,11 @@ variable "load-balancer-annotations" {
   description = "Annotations for the load balancer"
   type        = map(string)
   default     = null
+}
+
+# current options: "default", "letsencrypt", "" (i.e. disabled)
+variable "certificate-service" {
+  description = "The certificate service to use"
+  type        = string
+  default     = "default"
 }

--- a/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/variables.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/variables.tf
@@ -69,5 +69,5 @@ variable "load-balancer-annotations" {
 variable "certificate-service" {
   description = "The certificate service to use"
   type        = string
-  default     = "default"
+  default     = "self-signed"
 }

--- a/qhub/template/stages/04-kubernetes-ingress/variables.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/variables.tf
@@ -51,5 +51,5 @@ variable "load-balancer-annotations" {
 variable "certificate-service" {
   description = "The certificate service to use"
   type        = string
-  default     = "default"
+  default     = "self-signed"
 }

--- a/qhub/template/stages/04-kubernetes-ingress/variables.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/variables.tf
@@ -48,7 +48,6 @@ variable "load-balancer-annotations" {
   default     = null
 }
 
-# current options: "default", "letsencrypt", "" (i.e. disabled)
 variable "certificate-service" {
   description = "The certificate service to use"
   type        = string

--- a/qhub/template/stages/04-kubernetes-ingress/variables.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/variables.tf
@@ -16,11 +16,6 @@ variable "node_groups" {
   }))
 }
 
-variable "enable-certificates" {
-  description = "Enable certificates"
-  default     = false
-}
-
 variable "acme-email" {
   description = "ACME server email"
   default     = "qhub@example.com"
@@ -51,4 +46,11 @@ variable "load-balancer-annotations" {
   description = "Annotations for the load balancer"
   type        = map(string)
   default     = null
+}
+
+# current options: "default", "letsencrypt", "" (i.e. disabled)
+variable "certificate-service" {
+  description = "The certificate service to use"
+  type        = string
+  default     = "default"
 }


### PR DESCRIPTION
Fixes | Closes | Resolves #1418 

> Please remove anything marked as optional that you don't need to fill in.
> Choose one of the keywords preceding to refer to the issue this PR solves, followed by the issue number (e.g Fixes # 666).
> If there is no issue, remove the line. Remove this note after reading.

## Changes introduced in this PR:

- This change will allow qhub users to disable TLS certificates altogether. This might be needed for those with unique deployment requirements. 

## Types of changes

What types of changes does your PR introduce?

_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [ ] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [ ] No

## Documentation

Does your contribution include breaking changes or deprecations?
If so have you updated the documentation?

- [ ] Yes, docstrings
- [ ] Yes, main documentation
- [ ] Yes, deprecation notices

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered and more.
