### PR TITLE
Fix for helm extension overrides data type issue

### DIFF
--- a/qhub/template/stages/08-qhub-tf-extensions/modules/helm-extensions/main.tf
+++ b/qhub/template/stages/08-qhub-tf-extensions/modules/helm-extensions/main.tf
@@ -5,5 +5,5 @@ resource "helm_release" "custom-helm-deployment" {
   chart      = var.chart
   version    = var.chart_version
 
-  values = var.overrides
+  values = [jsonencode(var.overrides)]
 }

--- a/qhub/template/stages/08-qhub-tf-extensions/modules/helm-extensions/variables.tf
+++ b/qhub/template/stages/08-qhub-tf-extensions/modules/helm-extensions/variables.tf
@@ -27,6 +27,6 @@ variable "chart_version" {
 
 variable "overrides" {
   description = "Overrides for the helm chart values"
-  type        = list(any)
+  type        = any
   default     = []
 }


### PR DESCRIPTION
## Changes introduced in this PR:

Giving values in the overrides section in the helm extensions failing with "Inappropriate value for attribute 'values': list of string required". Fix is to accept jsonencoded 'any' value.
-

## Types of changes

What types of changes does your PR introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing
Ran manual tests of deployments

### Requires testing

- [x] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ x] Yes
- [ ] No

## Documentation

Does your contribution include breaking changes or deprecations?
If so have you updated the documentation?

- [ ] Yes, docstrings
- [ ] Yes, main documentation
- [ ] Yes, deprecation notices

