### PR TITLE
Fixing provider=existing for local/existing

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
         # additional
         pkgs.minikube
         pkgs.k9s
+        pkgs.expect
       ];
     in rec {
       defaultApp.x86_64-linux = pythonPackages.buildPythonPackage {

--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -195,7 +195,10 @@ def guided_install(
     check_cloud_credentials(config)
 
     stage_outputs = {}
-    if config["provider"] != "local" and config["terraform_state"]["type"] == "remote":
+    if (
+        config["provider"] not in {"existing", "local"}
+        and config["terraform_state"]["type"] == "remote"
+    ):
         if skip_remote_state_provision:
             print("Skipping remote state provision")
         else:

--- a/qhub/deploy.py
+++ b/qhub/deploy.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 def provision_01_terraform_state(stage_outputs, config):
     directory = "stages/01-terraform-state"
 
-    if config["provider"] == "local":
+    if config["provider"] in {"existing", "local"}:
         stage_outputs[directory] = {}
     else:
         stage_outputs[directory] = terraform.deploy(

--- a/qhub/destroy.py
+++ b/qhub/destroy.py
@@ -25,7 +25,10 @@ def gather_stage_outputs(config):
         terraform_destroy=False,
     )
 
-    if config["provider"] != "local" and config["terraform_state"]["type"] == "remote":
+    if (
+        config["provider"] not in {"existing", "local"}
+        and config["terraform_state"]["type"] == "remote"
+    ):
         stage_outputs["stages/01-terraform-state"] = _terraform_init_output(
             directory=os.path.join("stages/01-terraform-state", config["provider"]),
             input_vars=input_vars.stage_01_terraform_state(stage_outputs, config),
@@ -148,7 +151,10 @@ def destroy_stages(stage_outputs, config):
         ignore_errors=True,
     )
 
-    if config["provider"] != "local" and config["terraform_state"]["type"] == "remote":
+    if (
+        config["provider"] not in {"existing", "local"}
+        and config["terraform_state"]["type"] == "remote"
+    ):
         status["stages/01-terraform-state"] = _terraform_destroy(
             # acl and force_destroy do not import properly
             # and only get refreshed properly with an apply

--- a/qhub/render.py
+++ b/qhub/render.py
@@ -65,7 +65,10 @@ def render_template(output_directory, config_filename, force=False, dry_run=Fals
         "stages/07-kubernetes-services",
         "stages/08-qhub-tf-extensions",
     ]
-    if config["provider"] != "local" and config["terraform_state"]["type"] == "remote":
+    if (
+        config["provider"] not in {"existing", "local"}
+        and config["terraform_state"]["type"] == "remote"
+    ):
         directories.append(f"stages/01-terraform-state/{config['provider']}")
 
     source_dirs = [os.path.join(str(template_directory), _) for _ in directories]


### PR DESCRIPTION
This fixes and issue when using provider=existing in 0.4.4rc4. This is broken before the release. 

Can reproduce when using `qhub init existing ...`.