### PR TITLE
Adding option to supply additional arguments to ingress via `ingress.terraform_overrides.additional-arguments`

### DIFF
--- a/qhub/template/stages/04-kubernetes-ingress/main.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/main.tf
@@ -11,4 +11,5 @@ module "kubernetes-ingress" {
   certificate-secret-name   = var.certificate-secret-name
   load-balancer-annotations = var.load-balancer-annotations
   load-balancer-ip          = var.load-balancer-ip
+  additional-arguments      = var.additional-arguments
 }

--- a/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/main.tf
@@ -260,7 +260,9 @@ resource "kubernetes_deployment" "main" {
             # Enable debug logging. Useful to work out why something might not be
             # working. Fetch logs of the pod.
             "--log.level=${var.loglevel}",
-            ], local.add-certificate
+            ],
+            local.add-certificate,
+            var.additional-arguments,
           )
 
           port {

--- a/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/variables.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/modules/kubernetes/ingress/variables.tf
@@ -71,3 +71,9 @@ variable "certificate-service" {
   type        = string
   default     = "self-signed"
 }
+
+variable "additional-arguments" {
+  description = "Additional command line arguments to supply to traefik ingress"
+  type        = list(string)
+  default     = []
+}

--- a/qhub/template/stages/04-kubernetes-ingress/variables.tf
+++ b/qhub/template/stages/04-kubernetes-ingress/variables.tf
@@ -48,8 +48,16 @@ variable "load-balancer-annotations" {
   default     = null
 }
 
+
 variable "certificate-service" {
   description = "The certificate service to use"
   type        = string
   default     = "self-signed"
+}
+
+
+variable "additional-arguments" {
+  description = "Additional command line arguments to supply to traefik ingress"
+  type        = list(string)
+  default     = []
 }


### PR DESCRIPTION
ingress.terraform_overrides.additional-arguments: [...]

See https://doc.traefik.io/traefik/reference/static-configuration/cli/



