### PR TITLE
Pin dask ipywidgets version to `7.7.1`

### DIFF
--- a/qhub/initialize.py
+++ b/qhub/initialize.py
@@ -238,7 +238,7 @@ DEFAULT_ENVIRONMENTS = {
         "dependencies": [
             "python",
             "ipykernel",
-            "ipywidgets",
+            "ipywidgets==7.7.1",
             f"qhub-dask =={qhub_dask_version}",
             "python-graphviz",
             "pyarrow",


### PR DESCRIPTION
## Changes introduced in this PR:

- Pin `ipywidgets` to `7.7.1` for the Dask built-in environment.

The latest `ipywidgets` `8.x` removed an essential method used by `dask-gateway` when using the client widgets. This is a short-term solution.

## Types of changes

What types of changes does your PR introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [ ] Yes
- [x] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [ ] No

## Documentation

Does your contribution include breaking changes or deprecations?
If so have you updated the documentation?

- [ ] Yes, docstrings
- [ ] Yes, main documentation
- [ ] Yes, deprecation notices

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered and more.
