### PR TITLE
Pass AWS `region`, `kubernetes_version` to terraform scripts

### DIFF
--- a/qhub/stages/input_vars.py
+++ b/qhub/stages/input_vars.py
@@ -100,6 +100,8 @@ def stage_02_infrastructure(stage_outputs, config):
         return {
             "name": config["project_name"],
             "environment": config["namespace"],
+            "region": config["amazon_web_services"]["region"],
+            "kubernetes_version": config["amazon_web_services"]["kubernetes_version"],
             "node_groups": [
                 {
                     "name": key,


### PR DESCRIPTION
Fixes | Closes | Resolves #1490 

> Please remove anything marked as optional that you don't need to fill in.
> Choose one of the keywords preceding to refer to the issue this PR solves, followed by the issue number (e.g Fixes # 666).
> If there is no issue, remove the line. Remove this note after reading.

## Changes introduced in this PR:

- There were two lines missing that are needed to pass AWS region and kubernetes version to the Terraform scripts. 

## Types of changes

What types of changes does your PR introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [ ] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [ ] No

## Documentation

Does your contribution include breaking changes or deprecations?
If so have you updated the documentation?

- [ ] Yes, docstrings
- [ ] Yes, main documentation
- [ ] Yes, deprecation notices

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered and more.
