### PR TITLE
Enable ebs-csi driver on AWS, add region + kubernetes_version vars

### DIFF
--- a/qhub/template/stages/02-infrastructure/aws/main.tf
+++ b/qhub/template/stages/02-infrastructure/aws/main.tf
@@ -66,8 +66,10 @@ module "efs" {
 module "kubernetes" {
   source = "./modules/kubernetes"
 
-  name = local.cluster_name
-  tags = local.additional_tags
+  name               = local.cluster_name
+  tags               = local.additional_tags
+  region             = var.region
+  kubernetes_version = var.kubernetes_version
 
   cluster_subnets         = module.network.subnet_ids
   cluster_security_groups = [module.network.security_group_id]

--- a/qhub/template/stages/02-infrastructure/aws/modules/kubernetes/locals.tf
+++ b/qhub/template/stages/02-infrastructure/aws/modules/kubernetes/locals.tf
@@ -7,6 +7,7 @@ locals {
   node_group_policies = concat([
     "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
     "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy",
     aws_iam_policy.worker_autoscaling.arn
   ], var.node_group_additional_policies)
 

--- a/qhub/template/stages/02-infrastructure/aws/modules/kubernetes/locals.tf
+++ b/qhub/template/stages/02-infrastructure/aws/modules/kubernetes/locals.tf
@@ -1,7 +1,8 @@
 locals {
   cluster_policies = concat([
     "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy",
-    "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+    "arn:aws:iam::aws:policy/AmazonEKSServicePolicy",
+    "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy",
   ], var.cluster_additional_policies)
 
   node_group_policies = concat([

--- a/qhub/template/stages/02-infrastructure/aws/modules/kubernetes/main.tf
+++ b/qhub/template/stages/02-infrastructure/aws/modules/kubernetes/main.tf
@@ -48,3 +48,11 @@ resource "aws_eks_node_group" "main" {
 data "aws_eks_cluster_auth" "main" {
   name = aws_eks_cluster.main.name
 }
+
+resource "aws_eks_addon" "addons" {
+  for_each          = { for addon in var.addons : addon.name => addon }
+  cluster_name      = aws_eks_cluster.main.name
+  addon_name        = each.value.name
+  addon_version     = each.value.version
+  resolve_conflicts = "OVERWRITE"
+}

--- a/qhub/template/stages/02-infrastructure/aws/modules/kubernetes/variables.tf
+++ b/qhub/template/stages/02-infrastructure/aws/modules/kubernetes/variables.tf
@@ -58,17 +58,3 @@ variable "node_group_instance_type" {
   type        = string
   default     = "m5.large"
 }
-
-variable "addons" {
-  type = list(object({
-    name    = string
-    version = string
-  }))
-
-  default = [
-    {
-      name    = "aws-ebs-csi-driver"
-      version = "v1.11.4-eksbuild.1"
-    }
-  ]
-}

--- a/qhub/template/stages/02-infrastructure/aws/modules/kubernetes/variables.tf
+++ b/qhub/template/stages/02-infrastructure/aws/modules/kubernetes/variables.tf
@@ -14,6 +14,16 @@ variable "cluster_subnets" {
   type        = list(string)
 }
 
+variable "region" {
+  description = "AWS region for EKS cluster"
+  type        = string
+}
+
+variable "kubernetes_version" {
+  description = "AWS kubernetes version for EKS cluster"
+  type        = string
+}
+
 variable "cluster_security_groups" {
   description = "AWS security groups to use for EKS cluster"
   type        = list(string)
@@ -47,4 +57,18 @@ variable "node_group_instance_type" {
   description = "AWS instance types to use for kubernetes nodes"
   type        = string
   default     = "m5.large"
+}
+
+variable "addons" {
+  type = list(object({
+    name    = string
+    version = string
+  }))
+
+  default = [
+    {
+      name    = "aws-ebs-csi-driver"
+      version = "v1.11.4-eksbuild.1"
+    }
+  ]
 }

--- a/qhub/template/stages/02-infrastructure/aws/variables.tf
+++ b/qhub/template/stages/02-infrastructure/aws/variables.tf
@@ -8,6 +8,16 @@ variable "environment" {
   type        = string
 }
 
+variable "region" {
+  description = "AWS region for EKS cluster"
+  type        = string
+}
+
+variable "kubernetes_version" {
+  description = "AWS kubernetes version for EKS cluster"
+  type        = string
+}
+
 variable "node_groups" {
   description = "AWS node groups"
   type = list(object({


### PR DESCRIPTION
~Fixes | Closes | Resolves #~ Related to: #1488

## Changes introduced in this PR:

- Add required `aws-ebs-csi-driver` on AWS for kubernetes v1.23+
  - https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
  - 1.23 is now the latest Kubernetes version
- Corollary to  #1493 
  - ensure that `region` and `kubernetes_version` are passed to tf scripts 

## Types of changes

What types of changes does your PR introduce?

_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

### Requires testing

- [ ] Yes
- [ ] No

### In case you checked yes, did you write tests?

- [ ] Yes
- [ ] No

## Documentation

Does your contribution include breaking changes or deprecations?
If so have you updated the documentation?

- [ ] Yes, docstrings
- [ ] Yes, main documentation
- [ ] Yes, deprecation notices

## Further comments (optional)

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered and more.
